### PR TITLE
OIDC and logs-ppx

### DIFF
--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -87,6 +87,10 @@ let
     ocamlPackages = oself;
   };
 
+  oidcPackages = callPackage ./oidc {
+    ocamlPackages = oself;
+  };
+
   opamPackages = callPackage ./opam {
     ocamlPackages = oself;
   };
@@ -130,6 +134,7 @@ in
   logsPpxPackages //
   menhirPackages //
   morphPackages //
+  oidcPackages//
   opamPackages //
   piafPackages //
   reasonPackages //

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -73,6 +73,10 @@ let
     ocamlPackages = oself;
   };
 
+  logsPpxPackages = callPackage ./logs-ppx {
+    ocamlPackages = oself;
+  };
+
   menhirPackages = if !stdenv.lib.versionAtLeast osuper.ocaml.version "4.07"
     then {}
     else callPackage ./menhir {
@@ -111,7 +115,7 @@ in
   archiPackages //
   caqti-packages //
   conduit-packages //
-cookiePackages //
+  cookiePackages //
   dataloader-packages //
   faradayPackages //
   graphqlPackages //
@@ -123,6 +127,7 @@ cookiePackages //
   junitPackages //
   kafka-packages //
   lambda-runtime-packages //
+  logsPpxPackages //
   menhirPackages //
   morphPackages //
   opamPackages //

--- a/ocaml/logs-ppx/default.nix
+++ b/ocaml/logs-ppx/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, ocamlPackages, lib }:
+
+with ocamlPackages;
+let src = builtins.fetchurl {
+  url = https://github.com/ulrikstrid/logs-ppx/archive/v0.1.0.tar.gz;
+  sha256 = "0j8x81qc7k8p87rrw2nv9wasjjnq4hrfwcwk3a682p90gzdx9vcy";
+};
+
+in
+{
+  logs-ppx = ocamlPackages.buildDunePackage
+    {
+      pname = "logs-ppx";
+      version = "0.1.0";
+      inherit src;
+
+      propagatedBuildInputs = with ocamlPackages; [
+        ppxlib
+      ];
+
+      meta = {
+        description = "PPX to cut down on boilerplate when using Logs";
+        license = stdenv.lib.licenses.bsd3;
+      };
+    };
+}

--- a/ocaml/oidc/default.nix
+++ b/ocaml/oidc/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, ocamlPackages, lib }:
+
+with ocamlPackages;
+let src = builtins.fetchurl {
+  url = https://github.com/ulrikstrid/ocaml-oidc/archive/v0.1.1.tar.gz;
+  sha256 = "1k729n94zx5qjc701s41dn4bjyqxznzbrwck713rni4w3yzparys";
+};
+
+in
+{
+  oidc = ocamlPackages.buildDunePackage {
+    pname = "oidc";
+    version = "0.1.1";
+    inherit src;
+
+    propagatedBuildInputs = with ocamlPackages; [
+      jose
+      uri
+      yojson
+      logs
+      logs
+    ];
+
+    meta = {
+      description = "Base functions and types to work with OpenID Connect.";
+      license = stdenv.lib.licenses.bsd3;
+    };
+  };
+
+  oidc-client = ocamlPackages.buildDunePackage {
+    pname = "oidc-client";
+    version = "1.0.0";
+    inherit src;
+
+    propagatedBuildInputs = with ocamlPackages; [
+      oidc
+      jose
+      uri
+      yojson
+      logs
+      piaf
+    ];
+
+    meta = {
+      description = "OpenID Connect Relaying Party implementation built ontop of Piaf.";
+      license = stdenv.lib.licenses.bsd3;
+    };
+  };
+}


### PR DESCRIPTION
Hitting this error when building;

```
File "expander/sexp_grammar_lifter.ml", line 31, characters 44-69:
31 | let lift_string ~loc s = pexp_constant ~loc (Pconst_string (s, None))
                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^
Error: The constructor Pconst_string expects 3 argument(s),
       but is applied here to 2 argument(s)
```