### PR TITLE
Fix remaining CI failures

### DIFF
--- a/cross/ocaml.nix
+++ b/cross/ocaml.nix
@@ -90,6 +90,12 @@ in
       afl-persistent = osuper.afl-persistent.overrideAttrs (o: {
         OCAMLFIND_TOOLCHAIN = "${crossName}";
 
+        postPatch = ''
+          ${o.postPatch}
+          head -n -3 ./build.sh > ./temp.sh
+          mv temp.sh build.sh
+          chmod a+x ./build.sh
+        '';
         installPhase = ''
           ${buildPackages.opaline}/bin/opaline -prefix $out -libdir $out/lib/ocaml/${osuper.ocaml.version}/site-lib/ ${o.pname}.install
           OCAMLFIND_DESTDIR=$(dirname $OCAMLFIND_DESTDIR)/${crossName}-sysroot/lib/

--- a/default.nix
+++ b/default.nix
@@ -40,13 +40,13 @@ in
   # - 4.06 is used by BuckleScript
   ocaml-ng = super.ocaml-ng // oPs // {
     ocamlPackages = self.ocamlPackages;
-    ocamlPackages_multicore = (oPs.ocamlPackages_4_10.overrideScope' (oself: osuper: {
+    ocamlPackages_multicore = (oPs.ocamlPackages_4_12.overrideScope' (oself: osuper: {
       ocaml = osuper.ocaml.overrideAttrs (_: {
-        version = "4.10.0+multicore+no-effect-syntax";
-        hardeningDisable = [ "strictoverflow" ];
+        version = "4.12.0+multicore+effects";
+        # hardeningDisable = [ "strictoverflow" ];
         src = builtins.fetchurl {
-          url = https://github.com/ocaml-multicore/ocaml-multicore/archive/eabff64f6d35507a9ebd9d649c159f73891bebbf.tar.gz;
-          sha256 = "0mda1rzwf1hr4kx15q67g1awbihqrcky6zi96ps14jgk83didv4j";
+          url = https://github.com/ocaml-multicore/ocaml-multicore/archive/9468d8c91feac55c9b390e50c25b739de043e5e0.tar.gz;
+          sha256 = "0zymc0rm5kmydr97jdjbj0wdvlb0ldw57f2i7d915vf8xd0xz9ba";
         };
       });
     })).overrideScope' (callPackage ./ocaml { });

--- a/default.nix
+++ b/default.nix
@@ -66,7 +66,10 @@ in
     aarch64-multiplatform-musl =
       (super.pkgsCross.aarch64-multiplatform-musl.appendOverlays
         ((callPackage ./cross { inherit ocamlVersions; }) ++
-          (callPackage ./static { inherit ocamlVersions; })));
+          (callPackage ./static {
+            pkgsNative = self;
+            inherit ocamlVersions;
+          })));
   };
 
 

--- a/default.nix
+++ b/default.nix
@@ -54,6 +54,7 @@ in
 
   pkgsCross = super.pkgsCross // {
     musl64 = super.pkgsCross.musl64.appendOverlays (callPackage ./static {
+      pkgsNative = self;
       inherit ocamlVersions;
     });
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -92,7 +92,6 @@ websocketafPackages // {
   });
 
   batteries = osuper.batteries.overrideAttrs (o: {
-
     src =
       if lib.versionOlder "4.13" osuper.ocaml.version then
         builtins.fetchurl

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -92,10 +92,16 @@ websocketafPackages // {
   });
 
   batteries = osuper.batteries.overrideAttrs (o: {
-    src = builtins.fetchurl {
-      url = https://github.com/ocaml-batteries-team/batteries-included/archive/2e027673.tar.gz;
-      sha256 = "09gp2k3434xbchc8mm97ksqmi7ds7x204pqwf9d1kv56yvrcd6ld";
-    };
+
+    src =
+      if lib.versionOlder "4.13" osuper.ocaml.version then
+        builtins.fetchurl
+          {
+            url = https://github.com/ocaml-batteries-team/batteries-included/archive/2e027673.tar.gz;
+            sha256 = "09gp2k3434xbchc8mm97ksqmi7ds7x204pqwf9d1kv56yvrcd6ld";
+          }
+      else
+        o.src;
   });
 
   calendar = callPackage ./calendar { ocamlPackages = oself; };

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -91,6 +91,13 @@ websocketafPackages // {
     doCheck = ! stdenv.isDarwin;
   });
 
+  batteries = osuper.batteries.overrideAttrs (o: {
+    src = builtins.fetchurl {
+      url = https://github.com/ocaml-batteries-team/batteries-included/archive/2e027673.tar.gz;
+      sha256 = "09gp2k3434xbchc8mm97ksqmi7ds7x204pqwf9d1kv56yvrcd6ld";
+    };
+  });
+
   calendar = callPackage ./calendar { ocamlPackages = oself; };
 
   camlp5 = osuper.camlp5.overrideAttrs (o: {

--- a/static/default.nix
+++ b/static/default.nix
@@ -1,7 +1,15 @@
-{ lib, ocamlVersions }:
+{ pkgsNative, lib, ocamlVersions }:
 # Loosely adapted from https://github.com/serokell/tezos-packaging/blob/b7617f99/nix/static.nix
 
 [
+  # The OpenSSL override in `overlays.nix` would cause curl and its transitive
+  # closure to be recompiled because of its use within the fetchers. So for now
+  # we use the native fetchers.
+  # This should be revisited in the future, as it makes the fetchers
+  # unusable at runtime in the target env. XXX(anmonteiro: is this true?)
+  (self: super:
+    lib.filterAttrs (n: _: lib.hasPrefix "fetch" n) pkgsNative)
+
   (import ./overlays.nix)
 
   (self: super:

--- a/static/overlays.nix
+++ b/static/overlays.nix
@@ -45,12 +45,9 @@
   {
     stdenv = lib.foldl (lib.flip lib.id) super.stdenv [ makeStaticLibraries ];
 
-    zlib = (super.zlib.override {
+    zlib = removeUnknownFlagsAdapter (super.zlib.override {
       static = true;
-      # shared = false;
       splitStaticOutput = false;
-    }).overrideAttrs (o: {
-      configureFlags = (removeUnknownConfigureFlags o.configureFlags);
     });
 
     openssl = (super.openssl.override { static = true; }).overrideAttrs (o: {

--- a/static/overlays.nix
+++ b/static/overlays.nix
@@ -53,18 +53,4 @@
     openssl = (super.openssl.override { static = true; }).overrideAttrs (o: {
       configureFlags = lib.remove "no-shared" o.configureFlags;
     });
-
-    libkrb5 = addDisableShared super.libkrb5;
-    # db48 = super.db48.overrideAttrs (o: {
-    # hardeningDisable = (o.hardeningDisable or [ ]) ++ [ "format" ];
-    # });
-
-    # clasp = super.clasp.overrideAttrs (o: {
-    # configurePlatforms = [ ];
-    # configureFlags = ((removeUnknownConfigureFlags o.configureFlags) ++ [ "--static" ]);
-
-    # preBuild = "cd build/release_static";
-    # });
-
-    # kmod = removeUnknownFlagsAdapter (super.kmod.override { withStatic = true; });
   })


### PR DESCRIPTION
Use the native fetchers to avoid bootstrapping everything in the static
overlays