### PR TITLE
Ad esy-fhs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -21,7 +21,7 @@ in
   });
   inherit esy;
 
-  esy-fhs = callPackage ./ocaml/esy/fhs.nix { inherit esy; inherit (self) buildFHSUserEnv; };
+  esy-fhs = callPackage ./ocaml/esy/fhs.nix { inherit (self) buildFHSUserEnv esy; };
 
   pkgsStatic = super.pkgsStatic.appendOverlays (callPackage ./static { });
 

--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,7 @@ let
     import ./ocaml/overlay-ocaml-packages.nix {
       inherit lib callPackage;
     };
-
+  esy = callPackage ./ocaml/esy { };
 in
 
 (overlayOcamlPackages [ (callPackage ./ocaml { }) ] self super) // {
@@ -19,7 +19,9 @@ in
   opaline = (super.opaline.override {
     inherit (self) ocamlPackages;
   });
-  esy = callPackage ./ocaml/esy { };
+  inherit esy;
+
+  esy-fhs = callPackage ./ocaml/esy/fhs.nix { inherit esy; inherit (self) buildFHSUserEnv; };
 
   pkgsStatic = super.pkgsStatic.appendOverlays (callPackage ./static { });
 

--- a/ocaml/esy/fhs.nix
+++ b/ocaml/esy/fhs.nix
@@ -1,0 +1,14 @@
+{ esy, buildFHSUserEnv }:
+buildFHSUserEnv {
+  name = "esy-fhs";
+  targetPkgs = pkgs: with pkgs; [
+    ligo
+    esy
+  ];
+  extraBuildCommands = ''
+    cp ${esy}/lib/ocaml/4.12.0/site-lib/esy/esyBuildPackageCommand $out/usr/lib/esy
+    cp ${esy}/lib/ocaml/4.12.0/site-lib/esy/esyRewritePrefixCommand $out/usr/lib/esy
+  '';
+  runScript = "bash -c $SHELL";
+  meta = esy.meta // { description = "FHS-compaible version of esy"; };
+}


### PR DESCRIPTION
This PR adds a package `esy-fhs` that exposes a binary of the same name. When executed, it puts the user in a chroot environment that is FHS compatible and thus allows esy to be used as normal. 

I've only tested it on project (https://github.com/marigold/deku), but so far it seems to work.

The integration is probably a bit brittle - it would be better to run `esy`'s post-installation scripts in the FHS environment, but this is a start at least.