### PR TITLE
Fix cross-compilation

### DIFF
--- a/cross/default.nix
+++ b/cross/default.nix
@@ -1,9 +1,23 @@
-{ lib, buildPackages, callPackage }:
+{ buildPackages }:
 
 [
-  (lib.overlayOcamlPackages (callPackage ./ocaml.nix { }))
+  (self: super:
+    let
+      inherit (super) lib;
+      overlays = (import ./ocaml.nix {
+        inherit buildPackages;
+        inherit (super) lib
+          writeText
+          writeScriptBin
+          stdenv
+          bash;
+      });
+    in
+    (lib.overlayOcamlPackages
+      overlays
+      self
+      super))
   (self: super: {
-    opaline = buildPackages.opaline;
+    opaline = super.buildPackages.opaline;
   })
-
 ]

--- a/cross/ocaml.nix
+++ b/cross/ocaml.nix
@@ -301,18 +301,20 @@ in
               ocamldep = "${natocaml}/bin/ocamldep"
             '';
 
-          aarch64_findlib_conf = with oself; writeText "${b.name}-${crossName}.conf" ''
-            path(${crossName}) = "${findlib}/lib/ocaml/${ocaml.version}/site-lib:${path}"
-            ldconf(${crossName})="ignore"
-            stdlib(${crossName}) = "${ocaml}/lib/ocaml"
-            ocamlc(${crossName}) = "${ocaml}/bin/ocamlc"
-            ocamlopt(${crossName}) = "${ocaml}/bin/ocamlopt"
-            ocamlcp(${crossName}) = "${ocaml}/bin/ocamlcp"
-            ocamlmklib(${crossName}) = "${ocaml}/bin/ocamlmklib"
-            ocamlmktop(${crossName}) = "${ocaml}/bin/ocamlmktop"
-            ocamldoc(${crossName}) = "${natocaml}/bin/ocamldoc"
-            ocamldep(${crossName}) = "${ocaml}/bin/ocamldep"
-          '';
+          aarch64_findlib_conf =
+            let ocaml = oself.ocaml; in
+            writeText "${b.name}-${crossName}.conf" ''
+              path(${crossName}) = "${oself.findlib}/lib/ocaml/${ocaml.version}/site-lib:${path}"
+              ldconf(${crossName})="ignore"
+              stdlib(${crossName}) = "${ocaml}/lib/ocaml"
+              ocamlc(${crossName}) = "${ocaml}/bin/ocamlc"
+              ocamlopt(${crossName}) = "${ocaml}/bin/ocamlopt"
+              ocamlcp(${crossName}) = "${ocaml}/bin/ocamlcp"
+              ocamlmklib(${crossName}) = "${ocaml}/bin/ocamlmklib"
+              ocamlmktop(${crossName}) = "${ocaml}/bin/ocamlmktop"
+              ocamldoc(${crossName}) = "${natocaml}/bin/ocamldoc"
+              ocamldep(${crossName}) = "${ocaml}/bin/ocamldep"
+            '';
 
           findlib_conf = stdenv.mkDerivation {
             name = "${b.name}-findlib-conf";
@@ -333,6 +335,7 @@ in
           nativeBuildInputs = (o.nativeBuildInputs or [ ]) ++ (o.buildInputs or [ ]);
           buildInputs = (o.buildInputs or [ ]) ++ (o.nativeBuildInputs or [ ]);
           OCAMLFIND_CONF = "${findlib_conf}/findlib.conf";
+          OCAMLPATH = natPath;
         });
 
     in

--- a/default.nix
+++ b/default.nix
@@ -4,10 +4,7 @@ self: super:
 
 let
   inherit (super) lib stdenv fetchFromGitHub callPackage;
-  overlayOcamlPackages =
-    import ./ocaml/overlay-ocaml-packages.nix {
-      inherit lib callPackage;
-    };
+  overlayOcamlPackages = import ./ocaml/overlay-ocaml-packages.nix;
 
 in
 
@@ -29,7 +26,6 @@ in
       cross-overlays = callPackage ./cross { };
     in
     super.pkgsCross // {
-
       musl64 = super.pkgsCross.musl64.appendOverlays static-overlays;
 
       aarch64-multiplatform =

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -876,36 +876,6 @@ with oself;
   pecu = osuper.pecu.overrideAttrs (_: { doCheck = false; });
   unstrctrd = osuper.unstrctrd.overrideAttrs (_: { doCheck = false; });
 
-  uuidm = osuper.uuidm.overrideAttrs (_: {
-    src = builtins.fetchurl {
-      url = https://github.com/dbuenzli/uuidm/archive/da1de441840fd457b21166448f9503fcf6dc6518.tar.gz;
-      sha256 = "0vpdma904jmw42g0lav153yqzpzwlkwx8v0c8w39al8d2r4nfdb1";
-    };
-    buildPhase = "ocaml -I ${findlib}/lib/ocaml/${ocaml.version}/site-lib/ pkg/pkg.ml build --with-cmdliner false";
-  });
-
-  uutf = osuper.uutf.overrideAttrs (_: {
-    src = builtins.fetchurl {
-      url = https://github.com/dbuenzli/uutf/archive/refs/tags/v1.0.3.tar.gz;
-      sha256 = "1520njh9qaqflnj1xaawwhxdmn7r1p3wrh1j7w8y91g5y3zcp95z";
-    };
-  });
-
-  uunf = osuper.uunf.overrideAttrs (_: {
-    buildPhase = ''
-      # big enough stack size
-      export OCAMLRUNPARAM="l=1100000"
-      ${topkg.buildPhase}
-    '';
-  });
-
-  uuuu = osuper.uuuu.overrideAttrs (_: {
-    src = builtins.fetchurl {
-      url = https://github.com/mirage/uuuu/releases/download/v0.3.0/uuuu-0.3.0.tbz;
-      sha256 = "19n39yc7spgzpk9i70r0nhkwsb0bfbvbgpf8d863p0a3wgryhzkb";
-    };
-  });
-
   utop = osuper.utop.overrideAttrs (_: {
     version = "2.9.0";
     src = builtins.fetchurl {
@@ -916,6 +886,36 @@ with oself;
     prePatch = ''
       substituteInPlace src/lib/uTop_main.ml --replace "Clflags.unsafe_string" "(ref false)"
     '';
+  });
+
+  uuidm = osuper.uuidm.overrideAttrs (_: {
+    src = builtins.fetchurl {
+      url = https://github.com/dbuenzli/uuidm/archive/da1de441840fd457b21166448f9503fcf6dc6518.tar.gz;
+      sha256 = "0vpdma904jmw42g0lav153yqzpzwlkwx8v0c8w39al8d2r4nfdb1";
+    };
+    buildPhase = "ocaml -I ${findlib}/lib/ocaml/${ocaml.version}/site-lib/ pkg/pkg.ml build --with-cmdliner false";
+  });
+
+  uunf = osuper.uunf.overrideAttrs (_: {
+    buildPhase = ''
+      # big enough stack size
+      export OCAMLRUNPARAM="l=1100000"
+      ${topkg.buildPhase}
+    '';
+  });
+
+  uutf = osuper.uutf.overrideAttrs (_: {
+    src = builtins.fetchurl {
+      url = https://github.com/dbuenzli/uutf/archive/refs/tags/v1.0.3.tar.gz;
+      sha256 = "1520njh9qaqflnj1xaawwhxdmn7r1p3wrh1j7w8y91g5y3zcp95z";
+    };
+  });
+
+  uuuu = osuper.uuuu.overrideAttrs (_: {
+    src = builtins.fetchurl {
+      url = https://github.com/mirage/uuuu/releases/download/v0.3.0/uuuu-0.3.0.tbz;
+      sha256 = "19n39yc7spgzpk9i70r0nhkwsb0bfbvbgpf8d863p0a3wgryhzkb";
+    };
   });
 
   websocketaf = callPackage ./websocketaf { };
@@ -947,6 +947,8 @@ with oself;
     propagatedBuildInputs = o.propagatedBuildInputs ++ [ camlp-streams ];
     patches = [ ./camlpstreams.patch ];
   });
+
+  yuscii = osuper.yuscii.overrideAttrs (_: { doCheck = false; });
 
   # Jane Street packages
   async_websocket = osuper.buildDunePackage {
@@ -1162,6 +1164,4 @@ with oself;
   protocol_version_header = osuper.protocol_version_header.overrideAttrs (_: {
     propagatedBuildInputs = [ core_kernel ocaml-migrate-parsetree-2 ];
   });
-
-  yuscii = osuper.yuscii.overrideAttrs (_: { doCheck = false; });
 }

--- a/ocaml/overlay-ocaml-packages.nix
+++ b/ocaml/overlay-ocaml-packages.nix
@@ -1,5 +1,3 @@
-{ lib, callPackage }:
-
 let
   ocamlVersions = [ "4_06" "4_08" "4_09" "4_10" "4_11" "4_12" "4_13" ];
 in
@@ -9,6 +7,7 @@ extraOverlays:
 self: super:
 
 let
+  inherit (super) lib callPackage;
   overlayOcamlPackages = version: {
     "ocamlPackages_${version}" =
       builtins.foldl'

--- a/static/default.nix
+++ b/static/default.nix
@@ -1,4 +1,4 @@
-{ buildPackages, lib, callPackage }:
+{ buildPackages }:
 # Loosely adapted from https://github.com/serokell/tezos-packaging/blob/b7617f99/nix/static.nix
 
 [
@@ -8,9 +8,12 @@
   # This should be revisited in the future, as it makes the fetchers
   # unusable at runtime in the target env. XXX(anmonteiro: is this true?)
   (self: super:
-    lib.filterAttrs (n: _: lib.hasPrefix "fetch" n) buildPackages)
+    super.lib.filterAttrs (n: _: super.lib.hasPrefix "fetch" n) buildPackages)
 
   (import ./overlays.nix)
 
-  (lib.overlayOcamlPackages [ (callPackage ./ocaml.nix { }) ])
+  (self: super:
+    super.lib.overlayOcamlPackages [ (super.callPackage ./ocaml.nix { }) ]
+      self
+      super)
 ]

--- a/static/ocaml.nix
+++ b/static/ocaml.nix
@@ -1,4 +1,4 @@
-{ lib, callPackage }:
+{ lib }:
 let
   removeUnknownConfigureFlags = f: with lib;
     remove "--disable-shared"


### PR DESCRIPTION
Dune doesn't call findlib anymore to get the findlib conf for the default context (see https://github.com/ocaml/dune/pull/4281)