### PR TITLE
Add `makePkgs` to `flake.nix`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,5 +13,6 @@
       };
     };
     legacyPackages = self.packages."${system}";
+    makePkgs = attrs: import ./boot.nix attrs;
   }));
 }


### PR DESCRIPTION
Example usage:

```nix
{
  inputs.flake-utils.url = "github:numtide/flake-utils";
  inputs.nixpkgs.url = "/Users/anmonteiro/monorepo/nix-overlays";

  outputs = { self, nixpkgs, flake-utils }:
    flake-utils.lib.eachDefaultSystem (system:
      let
        inherit (nixpkgs) makePkgs;
        pkgs = makePkgs."${system}" { inherit system; };
      in
      {
        defaultPackage = pkgs.ocamlPackages.piaf;
      });
}

```