### PR TITLE
Fix auto-updater

### DIFF
--- a/.github/workflows/auto-update.js
+++ b/.github/workflows/auto-update.js
@@ -1,131 +1,122 @@
-const { url } = require("inspector");
+const {url} = require("inspector");
 
 const source_regex =
-  /name = "nixos-unstable-(20[0-9\-]+)";.    url = https:\/\/github\.com\/nixos\/nixpkgs\/archive\/([0-9a-z]+)\.tar\.gz;.    sha256 = "([0-9a-z]+)";/s;
+    /name = "nixos-unstable-(small-)?(20[0-9\-]+)";.    url = https:\/\/github\.com\/nixos\/nixpkgs\/archive\/([0-9a-z]+)\.tar\.gz;.    sha256 = "([0-9a-z]+)";/s;
 
-module.exports = async ({ github, context, core, require }) => {
+module.exports = async ({github, context, core, require}) => {
   const https = require("https");
-  const { URL } = require("url");
-  const { readFileSync, writeFileSync } = require("fs");
-  const { exec } = require("child_process");
+  const {URL} = require("url");
+  const {readFileSync, writeFileSync} = require("fs");
+  const {exec} = require("child_process");
 
   const http_request = (uri) => {
     return new Promise((resolve, reject) => {
       const url = new URL(uri);
 
       return https
-        .get(
-          {
-            port: 443,
-            path: url.pathname + url.search,
-            protocol: url.protocol,
-            hostname: url.hostname,
-            method: "GET",
-            headers: {
-              "User-Agent": "GithubActions",
-              Accept: "application/json",
+          .get({
+            port : 443,
+            path : url.pathname + url.search,
+            protocol : url.protocol,
+            hostname : url.hostname,
+            method : "GET",
+            headers : {
+              "User-Agent" : "GithubActions",
+              Accept : "application/json",
             },
             url,
           },
-          (res) => {
-            const response_data = [];
-            res.on("data", (data) => {
-              response_data.push(data);
-            });
+               (res) => {
+                 const response_data = [];
+                 res.on("data", (data) => { response_data.push(data); });
 
-            res.on("end", () => {
-              const response = Buffer.concat(response_data);
-              const response_string = response.toString();
-              resolve(JSON.parse(response_string));
-            });
-          }
-        )
-        .on("error", reject);
+                 res.on("end", () => {
+                   const response = Buffer.concat(response_data);
+                   const response_string = response.toString();
+                   resolve(JSON.parse(response_string));
+                 });
+               })
+          .on("error", reject);
     });
   };
 
   const get_revisions = () =>
-    http_request(
-      "https://monitoring.nixos.org/prometheus/api/v1/query?query=channel_revision"
-    )
-      .then((res) => res.data.result)
-      .then((rev) => [
-        rev.find((d) => d.metric.channel === "nixos-unstable"),
-        rev.find((d) => d.metric.channel === "nixos-unstable-small"),
-      ]);
+      http_request(
+          "https://monitoring.nixos.org/prometheus/api/v1/query?query=channel_revision")
+          .then((res) => res.data.result)
+          .then(
+              (rev) => [rev.find((d) => d.metric.channel === "nixos-unstable"),
+                        rev.find((d) => d.metric.channel ===
+                                        "nixos-unstable-small"),
+  ]);
 
   function get_sha256(url) {
     return new Promise((resolve, reject) => {
-      exec(
-        `nix-prefetch-url --type sha256 --unpack ${url}`,
-        (error, stdout, stderr) => {
-          if (error) {
-            return reject(error);
-          }
+      exec(`nix-prefetch-url --type sha256 --unpack ${url}`,
+           (error, stdout, stderr) => {
+             if (error) {
+               return reject(error);
+             }
 
-          const lines = stdout.trim().split("\n");
-          resolve(lines[0]);
-        }
-      );
+             const lines = stdout.trim().split("\n");
+             resolve(lines[0]);
+           });
     });
   }
 
   const get_newest = (revisions) => {
-    const urls = revisions
-      .map((revision) => revision.metric.revision)
-      .map(
-        (commit_sha) =>
-          `https://api.github.com/repos/nixos/nixpkgs/commits/${commit_sha}`
-      );
+    const urls =
+        revisions.map((revision) => revision.metric.revision)
+            .map((commit_sha) =>
+                     `https://api.github.com/repos/nixos/nixpkgs/commits/${
+                         commit_sha}`);
 
-    return Promise.all(urls.map(http_request)).then(([big, small]) => {
+    return Promise.all(urls.map(http_request)).then(([ big, small ]) => {
       const big_date = new Date(big.commit.committer.date);
       const small_date = new Date(small.commit.committer.date);
       if (big_date > small_date) {
         return {
-          date: big_date,
-          sha: big.sha,
-          channel: "nixos-unstable",
+          date : big_date,
+          sha : big.sha,
+          channel : "nixos-unstable",
         };
       } else {
         return {
-          date: small_date,
-          sha: small.sha,
-          channel: "nixos-unstable-small",
+          date : small_date,
+          sha : small.sha,
+          channel : "nixos-unstable-small",
         };
       }
     });
   };
 
-  const url = get_revisions()
-    .then(get_newest)
-    .then(async (revision) => {
-      const next_sha = revision.sha;
-      const next_url = `https://github.com/nixos/nixpkgs/archive/${next_sha}.tar.gz`;
-      const source_path = "./sources.nix";
+  const url = get_revisions().then(get_newest).then(async (revision) => {
+    const next_sha = revision.sha;
+    const next_url =
+        `https://github.com/nixos/nixpkgs/archive/${next_sha}.tar.gz`;
+    const source_path = "./sources.nix";
 
-      const next_sha256 = await get_sha256(next_url);
+    const next_sha256 = await get_sha256(next_url);
 
-      const year = revision.date.getFullYear();
-      const month = (revision.date.getMonth() + 1).toString().padStart(2, "0");
-      const day = revision.date.getDate().toString().padStart(2, "0");
+    const year = revision.date.getFullYear();
+    const month = (revision.date.getMonth() + 1).toString().padStart(2, "0");
+    const day = revision.date.getDate().toString().padStart(2, "0");
 
-      const old_source = readFileSync(source_path).toString();
-      const next_source = old_source.replace(
-        source_regex,
-        `name = "${revision.channel}-${year}-${month}-${day}";
+    const old_source = readFileSync(source_path).toString();
+    const next_source = old_source.replace(
+        source_regex, `name = "${revision.channel}-${year}-${month}-${day}";
     url = ${next_url};
-    sha256 = "${next_sha256}";`
-      );
+    sha256 = "${next_sha256}";`);
 
-      writeFileSync(source_path, next_source);
+    writeFileSync(source_path, next_source);
 
-      const [_full_match, _old_date, old_git_sha] =
+    const [_full_match, _channel_variant, _old_date, old_git_sha] =
         old_source.match(source_regex);
-      const url = `https://github.com/NixOS/nixpkgs/compare/${old_git_sha}...${next_sha}`;
+    const url =
+        `https://github.com/NixOS/nixpkgs/compare/${old_git_sha}...${next_sha}`;
 
-      return url;
-    });
+    return url;
+  });
 
   return url;
 };


### PR DESCRIPTION
- Since https://github.com/anmonteiro/nix-overlays/pull/191 we also consult the `nixos-unstable-small` channel
- In this scenario, the bot might write `name = "nixos-unstable-small-date`, messing up our regex
- this change fixes the regex to account for this detail


This is best reviewed [without whitespace diff](https://github.com/anmonteiro/nix-overlays/pull/207/files?diff=split&w=1), since I formatted the JS code using prettier.