### PR TITLE
Update sources

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -67,6 +67,8 @@ let
     "genspio"
     "lwt-exit"
     "ocaml-r"
+    "ocsigenserver"
+    "ocsipersist"
 
     "melange"
     # dune.configurator issue
@@ -158,7 +160,6 @@ let
     # Incompatible with 4.14
     "pcap-format"
     "eliom"
-    "ocsigenserver"
     "ocsigen_server"
     "ocsigen-toolkit"
     "ogg"

--- a/ci.nix
+++ b/ci.nix
@@ -158,6 +158,7 @@ let
     # Incompatible with 4.14
     "pcap-format"
     "eliom"
+    "ocsigenserver"
     "ocsigen_server"
     "ocsigen-toolkit"
     "ogg"

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -275,10 +275,6 @@ with oself;
       url = https://github.com/dbuenzli/cmdliner/archive/refs/tags/v1.1.1.tar.gz;
       sha256 = "07846phk06hi90a764ijlrkv9xh69bdn2msi5ah6c43s8pcf7rnv";
     };
-    buildPhase = "make all PREFIX=$out";
-    installPhase = ''
-      make install LIBDIR=$OCAMLFIND_DESTDIR/cmdliner
-    '';
   });
 
   conan = callPackage ./conan { };

--- a/sources.nix
+++ b/sources.nix
@@ -1,8 +1,8 @@
 {
   unstable = builtins.fetchTarball {
-    name = "nixos-unstable-small-2022-03-30";
-    url = https://github.com/nixos/nixpkgs/archive/1063244793d9b2dc3db515ac5b70a85385ec9b10.tar.gz;
-    sha256 = "1qigy10v2spgkfvm45vmh6yqb1xdsq35idgrybnvjwmcyzihym3n";
+    name = "nixos-unstable-small-2022-04-08";
+    url = https://github.com/nixos/nixpkgs/archive/e10e367defcb64675f021e82cc9e0a0f4ec4f0b4.tar.gz;
+    sha256 = "0pxmhbdg105ysy8p145mggff2n081r0s5x9w4sydbz9vh1jghna4";
   };
 
   staging = builtins.fetchTarball {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

Commits touching OCaml packages:

* [ocaml: fix build w/glibc-2.34

ChangeLog: https://hydra.nixos.org/build/154122673](https://github.com/NixOS/nixpkgs/commit/917b7e5fd2e29346040dc95a39cae17f92eae0dc)
* [ocaml 4.10/4.11: fix build w/glibc-2.34

Failing Hydra build: https://hydra.nixos.org/build/155189331
Applied a smaller patch from Fedora's fork[1] as it also applies on
older versions.

That said, these versions seem unmaintained anyways, so we should
probably drop them entirely.

[1] https://pagure.io/fedora-ocaml/c/dfb5e954a04f59b0456cc4c0ddf3acaf22e0ff07?branch=fedora-35-4.12.0](https://github.com/NixOS/nixpkgs/commit/bcf8aeff3c7fbf92d576f89dad6a21913f7eb37a)
* [ocaml: enable parallel building

Enable parallel building for ocaml-4.08 and above. tested as:

    $ nix build -f. ocaml-ng.ocamlPackages_{4_{00_1,01_0,02,03,04,05,06,07,08,09,10,11,12,13},latest}.ocaml --keep-going

ocaml build system supports parallel building, but but for multiple
top-level targets at the same time as it usually spawns subprocess
 that occasionally conflict with one another. To work it around
we use tiny Makefile with a single rule that calls top-level targets
sequentially as makefile calls:

    nixpkgs_world_bootstrap_world_opt:
        world
        bootstrap
        world.opt

On a 16-core machine ocaml-4.12 build speeds up from 6m55s to 1m35s.

Releases 4_00_1, 4_01_0, 4_04 and 4_05 still have some race in them.
Thus this change enables parallel builds only for ocaml-4.06 and above.

Adapted from #142723

upstreams's CI tests the parallel makefile: https://github.com/ocaml/ocaml/issues/10235#issuecomment-782100584
The limit was chosen to be 4.08 because it was released in 2019, not too
long before the above link.](https://github.com/NixOS/nixpkgs/commit/238d634e4b7cbe58c9d9fbc155ffcf19f25f2b12)
* [ocaml: rename name to pname](https://github.com/NixOS/nixpkgs/commit/103f0186e15a0485a9cd612b710e17e91e561e31)
* [ocamlPackages.caqti: 1.5.1 -> 1.7.0](https://github.com/NixOS/nixpkgs/commit/d1890aee144a04fcd93d4b0d848917d1e92c0e5d)
* [ocamlPackages.z3: Remove unecessary patch

Reported in https://github.com/Z3Prover/z3/issues/5776 and fixed in https://github.com/Z3Prover/z3/commit/4f6fcf8ea78492e1d90398bcd3a663f8517f2a66.](https://github.com/NixOS/nixpkgs/commit/9c83a461e5789eb22c8a6f4c28f632e058cc8410)
* [ocamlPackages.unionFind: init at 20220122](https://github.com/NixOS/nixpkgs/commit/366a59cdc312601b1d711a066e858bbf49bb9885)
* [ocaml-ng.ocamlPackages_4_14.ocaml: 4.14.0-rc2 → 4.14.0](https://github.com/NixOS/nixpkgs/commit/3a5df670ef8553575b7648ecf91d758626a48267)
* [ocamlPackages.type_conv: remove at 108.08.00, 109.60.01, 113.00.02](https://github.com/NixOS/nixpkgs/commit/1ddbc47dc7439f50d12e8daabd01efaa78320e39)
* [ocamlPackages.utop: 2.9.0 -> 2.9.1](https://github.com/NixOS/nixpkgs/commit/22f0589963ca7b6aaf2245e60954dcaa2770d3f5)
* [ocamlPackages.ocsipersist: init at 1.1.0

With support for SQLite and PostgreSQL](https://github.com/NixOS/nixpkgs/commit/994b21d1c198d8896db00cbc1e39fd41aaef18df)
* [ocamlPackages.eliom: 8.9.0 → 9.4.0](https://github.com/NixOS/nixpkgs/commit/684ae2716381a05fc92c0143ded6f2170271ce83)
* [ocamlPackages.ocsigen-start: 4.3.0 → 4.5.0](https://github.com/NixOS/nixpkgs/commit/b1a435eda00c1510d987a87e9cd28279d166031b)
* [ocamlPackages.ocsigenserver: 4.0.1 → 5.0.1](https://github.com/NixOS/nixpkgs/commit/1af918c494d8b0a55134d96e4c6a8bcba6c3b3cf)
* [ocamlPackages.ocsigen-toolkit: 3.0.1 → 3.1.1](https://github.com/NixOS/nixpkgs/commit/0c7c76fa9e2f5c7b446c1182c79eabac08588392)
* [ocamlPackages.sqlite3EZ: remove at 0.1.0

Broken by a13cdfe520d87db401dd000fbd67cad728162a60](https://github.com/NixOS/nixpkgs/commit/9bf28042f513bc7b54b7b4af5debaaf9a887478a)
* [ocamlPackages.asn1-combinators: disable with OCaml < 4.08

Fixes build failures introduced by fbac0f4a6d367974be3a8ee015fd403a679a3402](https://github.com/NixOS/nixpkgs/commit/ed1bc6d3699f825efd5c2aa319f3b00c6667c0df)
* [ocamlPackages.torch: Mark as broken with pytorch >= 1.11](https://github.com/NixOS/nixpkgs/commit/d240ca09aa43b3650da8b5b5ebc77053e7ecbaf6)
* [ocaml 4.00 – 4.09: make compatible with glibc-2.34](https://github.com/NixOS/nixpkgs/commit/d8d21367180ba7a3d21db6fb04196adfcd0421ab)
* [ocamlPackages.findlib: 1.9.1 → 1.9.3](https://github.com/NixOS/nixpkgs/commit/e7001451a509a3ae6ec75eddeeac161de30e69c3)
* [ocamlPackages.cmdliner: Use the upstream Makefile build rules (#166150)

* ocamlPackages.cmdliner: remove at 1.0.2

Remove a legacy version.

* ocamlPackages.cmdliner: use the upstream Makefile build rules

According to
https://github.com/dbuenzli/cmdliner/pull/147#issuecomment-1081168328,
the topkg build is deprecated.  Switch to the new recommended build instructions.](https://github.com/NixOS/nixpkgs/commit/05fe9b54a5782506c60d94b7eaefce7158da0d77)
      
Diff URL: https://github.com/NixOS/nixpkgs/compare/1063244793d9b2dc3db515ac5b70a85385ec9b10...e10e367defcb64675f021e82cc9e0a0f4ec4f0b4