### PR TITLE
Update sources

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -28,9 +28,6 @@ jobs:
           - { ocaml-version: 5_00, continue-on-error: true }
     name: Native packages (Linux, OCaml ${{ matrix.setup.ocaml-version }})
     runs-on: ubuntu-latest
-    # We want to run on external PRs, but not on our own internal PRs as
-    # they'll be run by the push to the branch.
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'anmonteiro/nix-overlays'
     env:
       NIXPKGS_ALLOW_UNFREE: 1
     steps:
@@ -59,7 +56,6 @@ jobs:
           - { ocaml-version: 4_14, continue-on-error: false }
           - { ocaml-version: 5_00, continue-on-error: true }
     name: Native packages (macOS, OCaml ${{ matrix.setup.ocaml-version }})
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'anmonteiro/nix-overlays'
     runs-on: macos-latest
     env:
       NIXPKGS_ALLOW_UNFREE: 1
@@ -93,7 +89,6 @@ jobs:
           - arm64
           - musl
     name: ${{matrix.target}} packages (OCaml ${{ matrix.setup.ocaml-version }})
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'anmonteiro/nix-overlays'
     runs-on: ubuntu-latest
     env:
       NIXPKGS_ALLOW_UNFREE: 1

--- a/ci.nix
+++ b/ci.nix
@@ -131,6 +131,7 @@ let
     "labltk"
     "camlimages"
     "apron"
+    "bjack"
 
     # broken with ppxlib 0.23
     "elpi"

--- a/ci.nix
+++ b/ci.nix
@@ -110,6 +110,7 @@ let
     "ffmpeg-avcodec"
     "ffmpeg-swscale"
     "ffmpeg-swresample"
+    "dssi"
 
     # doesn't work with my fork of http/af
     "paf"

--- a/sources.nix
+++ b/sources.nix
@@ -1,8 +1,8 @@
 {
   unstable = builtins.fetchTarball {
-    name = "nixos-unstable-small-2022-04-11";
-    url = https://github.com/nixos/nixpkgs/archive/1693e55bd218f2d055d82f4485f67d99521cf70a.tar.gz;
-    sha256 = "0626n2s19xb00hx761piyagaqbmn65bkw5nc3jvhkvd1syqpj0az";
+    name = "nixos-unstable-small-2022-04-19";
+    url = https://github.com/nixos/nixpkgs/archive/c10c8912eed56322bbe5e2124e53d0361d2017cb.tar.gz;
+    sha256 = "0qamglsw9s548m3d39v2qigb43c1ilf04vykgbw0kw01xzkfhcf4";
   };
 
   staging = builtins.fetchTarball {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

Commits touching OCaml packages:

* [ocamlPackages.phylogenetics: 0.0.0 -> 0.1.0](https://github.com/NixOS/nixpkgs/commit/983a9f4bb6fa8f450e932cba57e73c2bf70792bd)
* [ocamlPackages.coin: 0.1.3 → 0.1.4](https://github.com/NixOS/nixpkgs/commit/73a22ba300583b1e5247bac9778d7653d21e6ad3)
* [ocamlPackages.bjack: init at 0.1.6](https://github.com/NixOS/nixpkgs/commit/0bcf4a81c8886b57356e99b0f094e821fd0a06ab)
* [ocamlPackages.gen_js_api: init at 1.0.9

I chose 1.0.9 instead of the latest 1.1.0, to avoid having to upgrade
js_of_ocaml first.](https://github.com/NixOS/nixpkgs/commit/fd0b06056033fd45dd40edd71173afdd082fc692)
* [ocamlPackages.samplerate: init at 0.1.6](https://github.com/NixOS/nixpkgs/commit/ee672c823ed46d8eec1354e6570e699954e01993)
* [ocamlPackages.xmlplaylist: init at 0.1.5](https://github.com/NixOS/nixpkgs/commit/6a14836a53cb70a9c5ed26cff9d953fedd11c2ed)
* [ocamlPackages.lastfm: init at 0.3.3](https://github.com/NixOS/nixpkgs/commit/0a44fe4daed4a63a959ebaee7b7f902eb48a6320)
* [ocamlPackages.ladspa: init at 0.2.2](https://github.com/NixOS/nixpkgs/commit/0c7af2f43d9e9450026f57c59226be934763ee97)
* [ocamlPackages.dssi: init at 0.1.5](https://github.com/NixOS/nixpkgs/commit/2d1cfba3490ef02b5d5e40540289b171e54dab0a)
* [ocamlPackages.frontc: 3.4.1 -> 4.1.0](https://github.com/NixOS/nixpkgs/commit/78d682f23efabf5ba7bf33326205151c5a63ae2e)
* [ocamlPackages.bap: 2.2.0 -> 2.4.0](https://github.com/NixOS/nixpkgs/commit/3a510ac1ce5a81f11bba878be16e6fe6816d7586)
* [ocamlPackages.bap: use default version of llvm](https://github.com/NixOS/nixpkgs/commit/2e4ce50912e2f8c3236b9e96bc2c7a4b236fe20a)
* [ocamlPackages.ffmpeg: 1.1.0 -> 1.1.3](https://github.com/NixOS/nixpkgs/commit/ee122a33378d60a1699463733bd7fdb60fd389cb)

Diff URL: https://github.com/NixOS/nixpkgs/compare/1693e55bd218f2d055d82f4485f67d99521cf70a...c10c8912eed56322bbe5e2124e53d0361d2017cb