### PR TITLE
Update sources

### DIFF
--- a/sources.nix
+++ b/sources.nix
@@ -1,8 +1,8 @@
 {
   unstable = builtins.fetchTarball {
-    name = "nixos-unstable-small-2022-04-19";
-    url = https://github.com/nixos/nixpkgs/archive/c10c8912eed56322bbe5e2124e53d0361d2017cb.tar.gz;
-    sha256 = "0qamglsw9s548m3d39v2qigb43c1ilf04vykgbw0kw01xzkfhcf4";
+    name = "nixos-unstable-small-2022-04-21";
+    url = https://github.com/nixos/nixpkgs/archive/b06d35b406c2396dd1611dc8601138fa3d06ee60.tar.gz;
+    sha256 = "18rfsd5pjjpn9ay33aj302pa4q3p7qkfs8ik6i6rks1c6236s83p";
   };
 
   staging = builtins.fetchTarball {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

Commits touching OCaml packages:

* [ocamlPackages.ctypes: 0.18.0 -> 0.20.0](https://github.com/NixOS/nixpkgs/commit/8bbfaea1c130f5c5b96b94e8e7266a31aed3f7c3)
* [ocamlPackages.rebez: init unstable-2019-06-20](https://github.com/NixOS/nixpkgs/commit/b2b02f3026e2e44760d933af10525154c4799bae)
* [ocamlPackages.brisk-reconciler: init unstable-2020-12-02](https://github.com/NixOS/nixpkgs/commit/efd13315f77c6313f71feced31fef6fa972e0964)
* [ocamlPackages.flex: init unstable-2020-09-12](https://github.com/NixOS/nixpkgs/commit/ab0788c8f5c2109de29b3be5858fc32a9332a36d)
* [ocamlPackages.hacl-star-raw: fix aarch64-darwin](https://github.com/NixOS/nixpkgs/commit/3540cc8d16870c2a39f4254152e9be1cb2214473)
* [ocamlPackages.pure-splitmix: init at 0.3](https://github.com/NixOS/nixpkgs/commit/a7e62c21c1fbb36588e06dadd252f3fced6dbda2)
* [ocamlPackages.toml: 6.0.0 -> 7.0.0 (#165676)](https://github.com/NixOS/nixpkgs/commit/b1eef8c0f0d3ca1263590a16a36b1d1832b5d4f1)

Diff URL: https://github.com/NixOS/nixpkgs/compare/c10c8912eed56322bbe5e2124e53d0361d2017cb...b06d35b406c2396dd1611dc8601138fa3d06ee60