### PR TITLE
Update sources

### DIFF
--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -520,7 +520,7 @@ with oself;
   graphql_ppx = callPackage ./graphql_ppx { };
   graphql-cohttp = osuper.graphql-cohttp.overrideAttrs (o: {
     # https://github.com/NixOS/nixpkgs/pull/170664
-    nativeBuildInputs = [ crunch ];
+    nativeBuildInputs = [ ocaml dune findlib crunch ];
   });
 
   gsl = osuper.gsl.overrideAttrs (o: {

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -518,6 +518,10 @@ with oself;
   graphql-async = callPackage ./graphql/async.nix { };
 
   graphql_ppx = callPackage ./graphql_ppx { };
+  graphql-cohttp = osuper.graphql-cohttp.overrideAttrs (o: {
+    # https://github.com/NixOS/nixpkgs/pull/170664
+    nativeBuildInputs = [ crunch ];
+  });
 
   gsl = osuper.gsl.overrideAttrs (o: {
     src = builtins.fetchurl {

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -41,10 +41,6 @@ with oself;
 
 {
   alcotest = osuper.alcotest.overrideAttrs (_: {
-    src = builtins.fetchurl {
-      url = https://github.com/mirage/alcotest/releases/download/1.5.0/alcotest-js-1.5.0.tbz;
-      sha256 = "0v4ghia378g3l53r61fj98ljha0qxl82xp26y9frjy1dw03ija2l";
-    };
     # A snapshot test is failing because of the cmdliner upgrade.
     doCheck = false;
   });
@@ -262,13 +258,6 @@ with oself;
 
   carton = disableTests osuper.carton;
 
-  caqti = osuper.caqti.overrideAttrs (o: {
-    src = builtins.fetchurl {
-      url = https://github.com/paurkedal/ocaml-caqti/releases/download/v1.8.0/caqti-v1.8.0.tbz;
-      sha256 = "04jbk9x14963p2r82mdmkw8b64p7yv3qlcabwa8054az6czj6c16";
-    };
-  });
-
   cmdliner_1_0 = osuper.cmdliner;
 
   cmdliner = osuper.cmdliner.overrideAttrs (_: {
@@ -301,11 +290,6 @@ with oself;
   });
 
   ctypes = osuper.ctypes.overrideAttrs (o: {
-    src = builtins.fetchurl {
-      url = https://github.com/ocamllabs/ocaml-ctypes/archive/57f069897b36f784ff0296c40f726e3baf5d8a1d.tar.gz;
-      sha256 = "05wy8nxprj4ka1dk5h4nmnmlrqildmlrqx37pbyvc8az16awz5x3";
-    };
-
     propagatedBuildInputs = o.propagatedBuildInputs ++ [ libffi-oc ];
   });
 

--- a/sources.nix
+++ b/sources.nix
@@ -1,8 +1,8 @@
 {
   unstable = builtins.fetchTarball {
-    name = "nixos-unstable-small-2022-04-19";
-    url = https://github.com/nixos/nixpkgs/archive/c10c8912eed56322bbe5e2124e53d0361d2017cb.tar.gz;
-    sha256 = "0qamglsw9s548m3d39v2qigb43c1ilf04vykgbw0kw01xzkfhcf4";
+    name = "nixos-unstable-small-2022-04-27";
+    url = https://github.com/nixos/nixpkgs/archive/d6b996030dd21c6509803267584b9aca3e133a07.tar.gz;
+    sha256 = "1zjlnmph80i077cp1ywsfkv9p6y40f6i3dm6g3jc7f3xlq61vv4s";
   };
 
   staging = builtins.fetchTarball {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

Commits touching OCaml packages:

* [ocamlPackages.ctypes: 0.18.0 -> 0.20.0](https://github.com/NixOS/nixpkgs/commit/8bbfaea1c130f5c5b96b94e8e7266a31aed3f7c3)
* [ocamlPackages.rebez: init unstable-2019-06-20](https://github.com/NixOS/nixpkgs/commit/b2b02f3026e2e44760d933af10525154c4799bae)
* [ocamlPackages.brisk-reconciler: init unstable-2020-12-02](https://github.com/NixOS/nixpkgs/commit/efd13315f77c6313f71feced31fef6fa972e0964)
* [ocamlPackages.flex: init unstable-2020-09-12](https://github.com/NixOS/nixpkgs/commit/ab0788c8f5c2109de29b3be5858fc32a9332a36d)
* [ocamlPackages.hacl-star-raw: fix aarch64-darwin](https://github.com/NixOS/nixpkgs/commit/3540cc8d16870c2a39f4254152e9be1cb2214473)
* [ocamlPackages.pure-splitmix: init at 0.3](https://github.com/NixOS/nixpkgs/commit/a7e62c21c1fbb36588e06dadd252f3fced6dbda2)
* [ocamlPackages.toml: 6.0.0 -> 7.0.0 (#165676)](https://github.com/NixOS/nixpkgs/commit/b1eef8c0f0d3ca1263590a16a36b1d1832b5d4f1)
* [ocamlPackages.alcotest: 1.4.0 -> 1.5.0](https://github.com/NixOS/nixpkgs/commit/9ff2c0035f606c6b18830e1942431fedf0ecf0b0)
* [ocamlPackages.caqti: 1.7.0 -> 1.8.0](https://github.com/NixOS/nixpkgs/commit/165da7245c7c41383740c8ec11d6d76312a4ec78)
* [ocamlPackages.reperf: init 1.5.1](https://github.com/NixOS/nixpkgs/commit/5e2b2659dc462eaedb029568548a8623e014596a)
* [ocamlPackages.llvm: switch to python3](https://github.com/NixOS/nixpkgs/commit/4e4feb0e0666c44a53c130efaf1082060104408d)

Diff URL: https://github.com/NixOS/nixpkgs/compare/c10c8912eed56322bbe5e2124e53d0361d2017cb...d6b996030dd21c6509803267584b9aca3e133a07