### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1652527621,
-        "narHash": "sha256-hHqY6n8nAKk8St2+BDkCOvXaUQSeN8GHgQR1jDuc+to=",
+        "lastModified": 1652619010,
+        "narHash": "sha256-zU+htvHA8k/nc3U1/JNteVps1J/U2swhMgDqOtvAhFM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cca7c716c29a15e6653cb3fc4d7e08eacb726993",
+        "rev": "33fadf3131f4e9bb2f58349e699e93aba17244ba",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cca7c716c29a15e6653cb3fc4d7e08eacb726993",
+        "rev": "33fadf3131f4e9bb2f58349e699e93aba17244ba",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "ocaml-packages-overlay";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=cca7c716c29a15e6653cb3fc4d7e08eacb726993";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=33fadf3131f4e9bb2f58349e699e93aba17244ba";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href=https://github.com/NixOS/nixpkgs/commit/2fc228efaf48520896eed71a8109aa6492c72939><pre>ocamlPackages.otoml: 0.9.0 → 1.0.1; soupault: 3.2.0 → 4.0.0 (#173032)

* ocamlPackages.otoml: 0.9.0 → 1.0.1

* soupault: 3.2.0 → 4.0.0

> toastal: I'm switching the OPAM tarball link to codeberg for 4.0.0

— dmbaturin, #soupault Libera.Chat

As directed by the maintainer, the releases will now point to the
Codeberg Gitea Git forge instance. This is a win for open source code
platforms and users as they will not need to interact with a
proprietary code forge!</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/cca7c716c29a15e6653cb3fc4d7e08eacb726993...33fadf3131f4e9bb2f58349e699e93aba17244ba