### PR TITLE
Make `libpq` use `openssl-oc`

### DIFF
--- a/overlay/default.nix
+++ b/overlay/default.nix
@@ -47,7 +47,11 @@ in
 
   # Stripped down postgres without the `bin` part, to allow static linking
   # with musl
-  libpq = super.postgresql.override { enableSystemd = false; gssSupport = false; };
+  libpq = super.postgresql.override {
+    enableSystemd = false;
+    gssSupport = false;
+    openssl = self.openssl-oc;
+  };
 
   opaline = super.opaline.override { inherit (self) ocamlPackages; };
   esy = callPackage ../ocaml/esy { };


### PR DESCRIPTION
Use `openssl-oc` here to avoid potentially linking 2 openssl versions in OCaml projects