### PR TITLE
Revert "Add the extraOverlays directly (#302)"

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,8 @@
           config.allowUnfree = true;
         } // attrs);
         in
+        # You might read https://nixos.org/manual/nixpkgs/stable/#sec-overlays-argument and want to change this
+        # but because of how we're doing overlays we will be overriding any extraOverlays if we don't use `appendOverlays`
         pkgs.appendOverlays extraOverlays;
     } // flake-utils.lib.eachDefaultSystem (system:
       {

--- a/flake.nix
+++ b/flake.nix
@@ -34,11 +34,13 @@
         [ "x86_64-linux" "aarch64-darwin" ]);
 
       makePkgs = { system, extraOverlays ? [ ], ... }@attrs:
-        import nixpkgs ({
+        let pkgs = import nixpkgs ({
           inherit system;
-          overlays = [ self.overlays.${system}.default ] ++ extraOverlays;
+          overlays = [ self.overlays.${system}.default ];
           config.allowUnfree = true;
         } // attrs);
+        in
+        pkgs.appendOverlays extraOverlays;
     } // flake-utils.lib.eachDefaultSystem (system:
       {
         packages = self.makePkgs { inherit system; };

--- a/flake.nix
+++ b/flake.nix
@@ -40,8 +40,10 @@
           config.allowUnfree = true;
         } // attrs);
         in
-        # You might read https://nixos.org/manual/nixpkgs/stable/#sec-overlays-argument and want to change this
-        # but because of how we're doing overlays we will be overriding any extraOverlays if we don't use `appendOverlays`
+          /*
+            You might read https://nixos.org/manual/nixpkgs/stable/#sec-overlays-argument and want to change this
+            but because of how we're doing overlays we will be overriding any extraOverlays if we don't use `appendOverlays`
+          */
         pkgs.appendOverlays extraOverlays;
     } // flake-utils.lib.eachDefaultSystem (system:
       {


### PR DESCRIPTION
This reverts commit 2781952d689f183f0c4d6a6669ec44fdc55fea50.

"I believe it's because self.overlays.${system}.default will import on its own and replace sources with the patched pkgs and ignore extraOverlays"