### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1653315696,
-        "narHash": "sha256-7tLCnzCz/fq86NEoF9+g/NkQRA2J+nkgytc7l2HuWnY=",
+        "lastModified": 1653407748,
+        "narHash": "sha256-g9puJaILRTb9ttlLQ7IehpV7Wcy0n+vs8LOFu6ylQcM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c11d9597c1b3cdc4fb44cbab48deec2cfbaa5281",
+        "rev": "5ce6597eca7d7b518c03ecda57d45f9404b5e060",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c11d9597c1b3cdc4fb44cbab48deec2cfbaa5281",
+        "rev": "5ce6597eca7d7b518c03ecda57d45f9404b5e060",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "ocaml-packages-overlay";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=c11d9597c1b3cdc4fb44cbab48deec2cfbaa5281";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=5ce6597eca7d7b518c03ecda57d45f9404b5e060";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1305,6 +1305,8 @@ with oself;
     propagatedBuildInputs = [ openssl-oc.dev ];
   });
 
+  stringext = disableTests osuper.stringext;
+
   subscriptions-transport-ws = callPackage ./subscriptions-transport-ws { };
 
   syndic = buildDunePackage rec {

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1305,8 +1305,6 @@ with oself;
     propagatedBuildInputs = [ openssl-oc.dev ];
   });
 
-  stringext = disableTests osuper.stringext;
-
   subscriptions-transport-ws = callPackage ./subscriptions-transport-ws { };
 
   syndic = buildDunePackage rec {

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -281,14 +281,7 @@ with oself;
 
   carton = disableTests osuper.carton;
 
-  cmdliner_1_0 = osuper.cmdliner;
-
-  cmdliner = osuper.cmdliner.overrideAttrs (_: {
-    src = builtins.fetchurl {
-      url = https://github.com/dbuenzli/cmdliner/archive/refs/tags/v1.1.1.tar.gz;
-      sha256 = "07846phk06hi90a764ijlrkv9xh69bdn2msi5ah6c43s8pcf7rnv";
-    };
-  });
+  cmdliner = cmdliner_1_1;
 
   conan = callPackage ./conan { };
   conan-lwt = callPackage ./conan/lwt.nix { };
@@ -1564,6 +1557,7 @@ with oself;
     ];
     meta = {
       description = "Memtrace Viewer";
+      mainProgram = "memtrace-viewer";
     };
   };
 

--- a/overlay/default.nix
+++ b/overlay/default.nix
@@ -47,11 +47,13 @@ in
 
   # Stripped down postgres without the `bin` part, to allow static linking
   # with musl
-  libpq = super.postgresql.override {
+  libpq = (super.postgresql.override {
     enableSystemd = false;
     gssSupport = false;
     openssl = self.openssl-oc;
-  };
+  }).overrideAttrs (o: {
+    doCheck = false;
+  });
 
   opaline = super.opaline.override { inherit (self) ocamlPackages; };
   esy = callPackage ../ocaml/esy { };

--- a/static/ocaml.nix
+++ b/static/ocaml.nix
@@ -16,6 +16,8 @@ let
     b.overrideAttrs (o: {
       configureFlags = removeUnknownConfigureFlags (o.configureFlags or [ ]);
       configurePlatforms = [ ];
+      # Static doesn't propagate `checkInputs` so we don't run the tests here
+      doCheck = false;
       # Shouldn't need this after https://github.com/NixOS/nixpkgs/pull/145448
       # nativeBuildInputs = (o.nativeBuildInputs or [ ]) ++ (o.buildInputs or [ ]);
       # buildInputs = (o.buildInputs or [ ]) ++ (o.nativeBuildInputs or [ ]);


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href=https://github.com/NixOS/nixpkgs/commit/5a61d189974198bcf61b494f11aabb65a77cb03e><pre>ocamlPackages.cmdliner_1_1: init at 1.1.1

Add the latest version of cmdliner. This release broke many packages and
have more constraining dependencies so the previous version cannot be
removed from nixpkgs for now.

The previous version is still available as ocamlPackages.cmdliner_1_0
and ocamlPackages.cmdliner points to it for now.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/29750d369c0a6bbce1b4f57b4a6f63da06a31390><pre>ocamlformat: 0.20.1 -> 0.21.0

The cmdliner dependency changed.
Update older version to use cmdliner_1_0 explicitly to be ready when it
changes.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/bcbbbea82e5a0618f3a11126fea7210bb9af1031><pre>ocamlPackages.cmdliner_1_0: Update license

License changed on version 1.0.0 from bsd3 to isc.</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/b37e4c01b13e01f6a2ec87c55f5255e1efa03fdf><pre>ocamlPackages.linenoise: 1.3.0 -> 1.3.1</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/c11d9597c1b3cdc4fb44cbab48deec2cfbaa5281...5ce6597eca7d7b518c03ecda57d45f9404b5e060