### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1652776076,
-        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
         "type": "github"
       },
       "original": {
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1653750779,
-        "narHash": "sha256-yQ5bsgAnUMS/MB2uRi+RANcXtlNENYp5+CZNvDVGxFo=",
+        "lastModified": 1654012153,
+        "narHash": "sha256-In+gfoH2Tnf/UmpzeuGlfuexU2EC4QIelBsm2zMK5AE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fa66e6d444f37c80d973d75fd3e0d28e286d8ea4",
+        "rev": "49a2bcc6e2065909c701f862f9a1a62b3082b40a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fa66e6d444f37c80d973d75fd3e0d28e286d8ea4",
+        "rev": "49a2bcc6e2065909c701f862f9a1a62b3082b40a",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "ocaml-packages-overlay";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=fa66e6d444f37c80d973d75fd3e0d28e286d8ea4";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=49a2bcc6e2065909c701f862f9a1a62b3082b40a";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href=https://github.com/NixOS/nixpkgs/commit/c3e55aa79ac4d856eb8f309ff651173b0ebec7b4><pre>ocamlPackages.sedlex: remove at 1.99.5</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/5637570f510374806019c8bcfe5df2994790b02e><pre>ocamlPackages: rename sedlex_2 into sedlex</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/b8186ef950ef3360f9306a6c88f3cb218ecb926f><pre>ocamlPackages.sedlex: 2.4 → 2.5</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/f2be2aa1d5813720c568509a85e4d04eb533c8fc><pre>ocamlPackages.bwd: init at 2.0.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/a1e9a866e1cfa5ae02fdf52b2799c185ce24b0f8><pre>ocamlPackages.yuujinchou: init at 2.0.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/ff74ad6db307c1045c98eb5b183e9348c68cd42a><pre>ocamlPackages.cooltt: unstable-2021-05-25 → unstable-2022-04-28</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/d27cc392f04381074e5c71a2d5356442b1610cac><pre>ocamlPackages.resto:  0.6.1 -> 0.7</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/a9ce8f1ef222c4b03773e5931176189cb59daa8b><pre>ocamlPackages.json-data-encoding: 0.10 -> 0.11</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/fa66e6d444f37c80d973d75fd3e0d28e286d8ea4...49a2bcc6e2065909c701f862f9a1a62b3082b40a