### PR TITLE
Fix dune packages

### DIFF
--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -424,6 +424,10 @@ with oself;
       rm -r vendor/csexp vendor/pp
     '';
   });
+  dune-action-plugin = osuper.dune-action-plugin.overrideAttrs (o: {
+    propagatedBuildInputs = o.propagatedBuildInputs ++ [ pp ];
+    inherit (dyn) preBuild;
+  });
   dune-glob = osuper.dune-glob.overrideAttrs (o: {
     propagatedBuildInputs = o.propagatedBuildInputs ++ [ pp ];
     inherit (dyn) preBuild;

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -415,8 +415,31 @@ with oself;
   dune-rpc = osuper.dune-rpc.overrideAttrs (_: {
     buildInputs = [ ];
     propagatedBuildInputs = [ stdune ordering pp xdg dyn ];
+    inherit (dyn) preBuild;
   });
   dune-rpc-lwt = callPackage ./dune/rpc-lwt.nix { };
+  dyn = osuper.dyn.overrideAttrs (o: {
+    propagatedBuildInputs = o.propagatedBuildInputs ++ [ pp ];
+    preBuild = ''
+      rm -r vendor/csexp vendor/pp
+    '';
+  });
+  dune-private-libs = osuper.dune-private-libs.overrideAttrs (o: {
+    propagatedBuildInputs = o.propagatedBuildInputs ++ [ pp ];
+    inherit (dyn) preBuild;
+  });
+  dune-site = osuper.dune-site.overrideAttrs (o: {
+    propagatedBuildInputs = o.propagatedBuildInputs ++ [ pp ];
+    inherit (dyn) preBuild;
+  });
+  fiber = osuper.fiber.overrideAttrs (o: {
+    propagatedBuildInputs = [ pp ];
+    inherit (dyn) preBuild;
+  });
+  stdune = osuper.stdune.overrideAttrs (o: {
+    propagatedBuildInputs = o.propagatedBuildInputs ++ [ pp ];
+    inherit (dyn) preBuild;
+  });
 
   dune-release = osuper.dune-release.overrideAttrs (o: {
     src = builtins.fetchurl {
@@ -1636,6 +1659,27 @@ with oself;
       sha256 = "179f1iz504l008b3p3d9q2nj44wv7y31pc997x32m6aq1j2lfip3";
     };
   });
+
+  ppx_yojson_conv_lib = janePackage {
+    pname = "ppx_yojson_conv_lib";
+    version = "0.15.0";
+    hash = "sha256-Hpg4AKAe7Q5P5UkBpH+5l1nZbIVA2Dr1Q30D4zkrjGo=";
+    propagatedBuildInputs = [ yojson ];
+    meta = {
+      description = "Yojson Deriver PPX";
+    };
+  };
+
+  ppx_yojson_conv = janePackage {
+    pname = "ppx_yojson_conv";
+    version = "0.15.0";
+    hash = "sha256-FGtReLkdI9EnD6sPsMQSv5ipfDyY6z5fIkjqH+tie48=";
+    propagatedBuildInputs = [ ppxlib ppx_yojson_conv_lib ppx_js_style ];
+    meta = {
+      description = "Yojson Deriver PPX";
+    };
+  };
+
 
   sexp_pretty = osuper.sexp_pretty.overrideAttrs (_: {
     patches =

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -424,6 +424,10 @@ with oself;
       rm -r vendor/csexp vendor/pp
     '';
   });
+  dune-glob = osuper.dune-glob.overrideAttrs (o: {
+    propagatedBuildInputs = o.propagatedBuildInputs ++ [ pp ];
+    inherit (dyn) preBuild;
+  });
   dune-private-libs = osuper.dune-private-libs.overrideAttrs (o: {
     propagatedBuildInputs = o.propagatedBuildInputs ++ [ pp ];
     inherit (dyn) preBuild;

--- a/ocaml/reason/default.nix
+++ b/ocaml/reason/default.nix
@@ -37,4 +37,6 @@ buildDunePackage rec {
   patches = [
     ./patches/0001-rename-labels.patch
   ];
+
+  meta.mainProgram = "refmt";
 }

--- a/ocaml/reason/rtop.nix
+++ b/ocaml/reason/rtop.nix
@@ -5,4 +5,6 @@ buildDunePackage {
   pname = "rtop";
   buildInputs = [ cppo ];
   propagatedBuildInputs = [ utop reason ];
+
+  meta.mainProgram = "rtop";
 }


### PR DESCRIPTION
These are apparently broken upstream, even though they tried to apply our previous fixes.

You can't use these packages with `pp` without getting an error about inconsistent assumptions.