### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1654012153,
-        "narHash": "sha256-In+gfoH2Tnf/UmpzeuGlfuexU2EC4QIelBsm2zMK5AE=",
+        "lastModified": 1655087213,
+        "narHash": "sha256-4R5oQ+OwGAAcXWYrxC4gFMTUSstGxaN8kN7e8hkum/8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "49a2bcc6e2065909c701f862f9a1a62b3082b40a",
+        "rev": "37b6b161e536fddca54424cf80662bce735bdd1e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "49a2bcc6e2065909c701f862f9a1a62b3082b40a",
+        "rev": "37b6b161e536fddca54424cf80662bce735bdd1e",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "ocaml-packages-overlay";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=49a2bcc6e2065909c701f862f9a1a62b3082b40a";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=37b6b161e536fddca54424cf80662bce735bdd1e";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href=https://github.com/NixOS/nixpkgs/commit/1bdc32f97002440304c620ef6f1dadc49ab9a6b1><pre>ocaml-ng.ocamlPackages_4_00_1.ocaml, ocaml-ng.ocamlPackages_4_08.ocaml: add -fcommon workaround

Workaround build failure on -fno-common toolchains like upstream
gcc-10. Otherwise build fails as:

    $ nix build --impure --expr \'with import ./. {}; ocaml-ng.ocamlPackages_4_00_1.ocaml.overrideAttrs (oa: {   NIX_CFLAGS_COMPILE = (["-fno-common"] ++ [oa.NIX_CFLAGS_COMPILE or ""]); })\'
    ...
    > ld: libcamlrun.a(startup.o):(.bss+0x800): multiple definition of `caml_code_fragments_table\'; libcamlrun.a(backtrace.o):(.bss+0x20): first defined here
    > collect2: error: ld returned 1 exit status</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/5feacad6948061f30853107421827d3a2f1ebd06><pre>ocamlPackages.tsdl: 0.9.7 -> 0.9.8</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/b161742e8667b4c131bd04952061d1d22a57566f><pre>ocamlPackages.tsdl-image: init 0.3.2</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/174d0fbddaaa997c15cde4164599b51c457d3199><pre>ocamlPackages.tsdl-ttf: init 0.3.2</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/13785fcc8fe1fa281979c3e378ae3923bb3170e6><pre>ocamlPackages.tsdl-mixer: init 0.3.2</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/fc29ad0a35382f24dce7ecd530d8f86cbd1926a8><pre>ocamlformat: 0.21.0 -> 0.22.4</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/e4fc3bea2fbe8bbf330b7062a4855801ef0ce779><pre>ocamlformat: remove older versions 0.12.x .. 0.18.x</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/31194524277dbba788123cf926348c2a85385178><pre>ocamlformat: remove unnecessary version check</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/81008f02c420a34097f2c612edf08cf298c695c5><pre>ocamlPackages.menhir: 20211128 → 20220210</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/e5b2c5f447ff3cadbbaff89ef2d547eee07c250d><pre>ocamlPackages.alsa: init at 3.0.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/e5031b839b07a5432f12fd2505339c7cbdaabfd4><pre>ocamlPackages.gstreamer: init at 0.3.1</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/754433d82a58d18a3c492cc84b4eae794766d648><pre>ocamlPackages.portaudio: init at 0.2.3</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7ed016627f9b7c3a0ab068cb526ad37ec2f8bcc7><pre>ocamlPackages.pulseaudio: init at 0.1.5</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/f3c53f430f18e5c0a3c5d38669db5b817aabf2a2><pre>ocamlPackages.dtools: init at 0.4.4</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/85665ca9d489a6cc1352f9c16abe3106ea2f0d2d><pre>ocamlPackages.duppy: init at 0.9.2</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/11208c64001f7c0c0073b6fd47c21bd9b1aff8aa><pre>ocamlPackages.lo: init at 0.2.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/60ff8d2306663d08621247b9416351a36183492e><pre>ocamlPackages.magic: init at 0.7.3</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/5e76c6961d1b992046781c21c7d7dfd5df60d013><pre>ocamlPackages.ao: init at 0.2.4</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/fbfd28e8ac8585dd9cb2e5cadfdfaf8597f9ad0a><pre>ocamlPackages.mad: init at 0.5.2</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/5a862299e02b49126d44844e60d343c74eff8a9f><pre>ocamlPackages.mm: init at 0.8.1</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/50cac6ed5ed534f8a1539349863599ade91295e7><pre>ocamlPackages.unix-errno: init at 0.6.1</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/cb26845685076ac02be9b9972a712d500fec9384><pre>ocamlPackages.posix-time2: init at 2.0.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/ab7173f6db30fcffe01a23d85138449fa990cabf><pre>ocamlPackages.srt: 0.1.1 -> 0.2.1</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/18aaa33f07a5193c18448d6f382a3c6662842ffc><pre>ocamlPackages.elpi: 1.14.1 → 1.15.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/f7373e4932d73da83f6c59b8d28bf53faf97ca2f><pre>ocamlPackages.elpi: 1.15.0 → 1.15.2

Co-authored-by: Pierre Roux <pierre.roux@onera.fr></pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/174c0a086e60e3ea2ac21077200145e054eda0c8><pre>ocamlPackages.cry: init at 0.6.5</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/866dbd9d4208a63df2cb6a2e4ae54ceeb7195472><pre>ocamlPackages.faad: init at 0.5.1</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/430b2bc83b3c67526f134fc06afc977dffb061a4><pre>ocamlPackages.lame: init at 0.3.6</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/f34e9c30025fb1300a25e53c2c9aa794ad377af4><pre>ocamlPackages.frei0r: init at 0.1.2</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/89a381788e217161d610030b80f3f79e26faa7ef><pre>ocamlPackages.soundtouch: init at 0.1.9</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/c035e81dacae0f74a5c81e08aefa904e8c418aee><pre>ocamlPackages.taglib: init at 0.3.9</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/592f58a1900b95d814e545f38c95ec4c613f5075><pre>ocamlPackages.lilv: init at 0.1.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/b64a90b182c7bd96a72fda511809ab65a50588f6><pre>ocamlPackages.ocurl: 0.9.1 -> 0.9.2</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/3a5d3c73c78cb63df07fce947a2fe5e6058069a3><pre>ocamlPackages.wasm: 1.1.1 → 2.0.0</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/49a2bcc6e2065909c701f862f9a1a62b3082b40a...37b6b161e536fddca54424cf80662bce735bdd1e