### PR TITLE
Update sources

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -44,8 +44,8 @@ jobs:
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
       - name: Build nix packages
         run: |
-          nix shell --print-build-logs -f ./ nix-build-uncached -c \
-              nix-build-uncached ./ci \
+          # nix shell --print-build-logs -f ./ nix-build-uncached -c \
+              nix-build ./ci \
                 --argstr ocamlVersion ${{ matrix.setup.ocaml-version }} \
                 --argstr target native \
                 --show-trace --keep-going
@@ -71,8 +71,8 @@ jobs:
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
       - name: Build nix packages
         run: |
-          nix shell --print-build-logs -f ./ nix-build-uncached -c \
-              nix-build-uncached ./ci \
+          # nix shell --print-build-logs -f ./ nix-build-uncached -c \
+              nix-build ./ci \
                 --arg ocamlVersion null \
                 --argstr target top-level-packages \
                 --show-trace --keep-going

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - master
-      # - auto-update-sources-*
 jobs:
   fmt:
     runs-on: ubuntu-latest
@@ -46,8 +45,8 @@ jobs:
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
       - name: Build nix packages
         run: |
-          # nix shell --print-build-logs -f ./ nix-build-uncached -c \
-              nix-build ./ci \
+          nix shell --print-build-logs -f ./ nix-build-uncached -c \
+              nix-build-uncached ./ci \
                 --argstr ocamlVersion ${{ matrix.setup.ocaml-version }} \
                 --argstr target native \
                 --show-trace --keep-going
@@ -73,8 +72,8 @@ jobs:
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
       - name: Build nix packages
         run: |
-          # nix shell --print-build-logs -f ./ nix-build-uncached -c \
-              nix-build ./ci \
+          nix shell --print-build-logs -f ./ nix-build-uncached -c \
+              nix-build-uncached ./ci \
                 --arg ocamlVersion null \
                 --argstr target top-level-packages \
                 --show-trace --keep-going
@@ -105,8 +104,8 @@ jobs:
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
       - name: Build nix packages
         run: |
-          # nix shell --print-build-logs -f ./ nix-build-uncached -c \
-              nix-build ./ci \
+          nix shell --print-build-logs -f ./ nix-build-uncached -c \
+              nix-build-uncached ./ci \
                 --argstr ocamlVersion ${{ matrix.setup.ocaml-version }} \
                 --argstr target native \
                 --show-trace --keep-going

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,10 +1,12 @@
 name: Pipeline
 on:
   pull_request:
+    branches:
+    - master
   push:
     branches:
       - master
-      - auto-update-sources-*
+      # - auto-update-sources-*
 jobs:
   fmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -103,8 +103,8 @@ jobs:
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
       - name: Build nix packages
         run: |
-          nix shell --print-build-logs -f ./ nix-build-uncached -c \
-              nix-build-uncached ./ci \
+          # nix shell --print-build-logs -f ./ nix-build-uncached -c \
+              nix-build ./ci \
                 --argstr ocamlVersion ${{ matrix.setup.ocaml-version }} \
                 --argstr target native \
                 --show-trace --keep-going

--- a/add-janestreet-packages-0_15.patch
+++ b/add-janestreet-packages-0_15.patch
@@ -1,88 +1,5 @@
-From e9a407161256e3a958ef78345bf749ed228b6d5d Mon Sep 17 00:00:00 2001
-From: "Aaron L. Zeng" <me@bcc32.com>
-Date: Sat, 28 May 2022 00:48:07 -0400
-Subject: [PATCH 1/2] comby: 1.7.0 -> 1.7.1
-
----
- pkgs/development/tools/comby/default.nix | 5 +++--
- 1 file changed, 3 insertions(+), 2 deletions(-)
-
-diff --git a/pkgs/development/tools/comby/default.nix b/pkgs/development/tools/comby/default.nix
-index 9b77740979e5f..cd3251841ad14 100644
---- a/pkgs/development/tools/comby/default.nix
-+++ b/pkgs/development/tools/comby/default.nix
-@@ -14,7 +14,7 @@ let
-   mkCombyPackage = { pname, extraBuildInputs ? [ ], extraNativeInputs ? [ ], preBuild ? "" }:
-     ocamlPackages.buildDunePackage rec {
-       inherit pname preBuild;
--      version = "1.7.0";
-+      version = "1.7.1";
-       useDune2 = true;
-       minimumOcamlVersion = "4.08.1";
-       doCheck = true;
-@@ -23,7 +23,7 @@ let
-         owner = "comby-tools";
-         repo = "comby";
-         rev = version;
--        sha256 = "sha256-Y2RcYvJOSqppmxxG8IZ5GlFkXCOIQU+1jJZ6j+PBHC4";
-+        sha256 = "0k60hj8wcrvrk0isr210vnalylkd63ria1kgz5n49inl7w1hfwpv";
-       };
- 
-       nativeBuildInputs = [
-@@ -82,6 +82,7 @@ mkCombyPackage {
-     ocamlPackages.parany
-     ocamlPackages.conduit-lwt-unix
-     ocamlPackages.lwt_react
-+    ocamlPackages.tar-unix
-     ocamlPackages.tls
-     combyKernel
-     combySemantic
-
-From f02c708e414723b428ce8221a5bc6084c6c49f5a Mon Sep 17 00:00:00 2001
-From: "Aaron L. Zeng" <me@bcc32.com>
-Date: Mon, 23 May 2022 01:18:37 -0400
-Subject: [PATCH 2/2] WIP: Add Jane Street ocaml packages version 0.15
-
-- TODO: Fix ppx_base not including ppx_js_style; breaks cinaps
-
-- ocamlPackages.tls*: 0.15.2 -> 0.15.3
-- ocamlPackages.bistro: unstable-2021-11-13 -> unstable-2022-05-07
-- ocamlPackages.phylogenetics: 0.1.0 -> unstable-2022-05-06
----
- pkgs/development/compilers/ligo/default.nix   |    3 +
- pkgs/development/compilers/ligo/ligo.patch    |  134 +++
- .../development/ocaml-modules/bap/default.nix |   10 +-
- .../ocaml-modules/biocaml/default.nix         |    9 +-
- .../ocaml-modules/bistro/default.nix          |   11 +-
- .../ocaml-modules/cohttp/async.nix            |   12 +-
- .../ocaml-modules/faraday/async.nix           |    7 +-
- .../ocaml-modules/hack_parallel/default.nix   |    8 +-
- .../hack_parallel/hack_parallel.patch         |   68 ++
- .../ocaml-modules/janestreet/0.15.nix         | 1000 ++++++++++++++++
- .../janestreet/bonsai_jsoo_4_0.patch          |   13 +
- .../janestreet/janePackage_0_15.nix           |   31 +
- .../ocaml-modules/janestreet/pythonlib.patch  |   22 +
- .../ocaml-modules/phylogenetics/default.nix   |   17 +-
- .../development/ocaml-modules/tls/default.nix |    6 +-
- pkgs/development/tools/comby/comby.patch      | 1025 +++++++++++++++++
- pkgs/development/tools/comby/default.nix      |    3 +
- pkgs/tools/misc/flitter/default.nix           |   12 +-
- pkgs/tools/misc/flitter/flitter.patch         |   13 +
- pkgs/tools/misc/patdiff/default.nix           |    4 +-
- pkgs/tools/typesetting/satysfi/default.nix    |    2 +
- pkgs/top-level/ocaml-packages.nix             |   11 +-
- 22 files changed, 2389 insertions(+), 32 deletions(-)
- create mode 100644 pkgs/development/compilers/ligo/ligo.patch
- create mode 100644 pkgs/development/ocaml-modules/hack_parallel/hack_parallel.patch
- create mode 100644 pkgs/development/ocaml-modules/janestreet/0.15.nix
- create mode 100644 pkgs/development/ocaml-modules/janestreet/bonsai_jsoo_4_0.patch
- create mode 100644 pkgs/development/ocaml-modules/janestreet/janePackage_0_15.nix
- create mode 100644 pkgs/development/ocaml-modules/janestreet/pythonlib.patch
- create mode 100644 pkgs/development/tools/comby/comby.patch
- create mode 100644 pkgs/tools/misc/flitter/flitter.patch
-
 diff --git a/pkgs/development/compilers/ligo/default.nix b/pkgs/development/compilers/ligo/default.nix
-index 36ec5bba2e20b..ab61043048af5 100644
+index 36ec5bba2e2..ab61043048a 100644
 --- a/pkgs/development/compilers/ligo/default.nix
 +++ b/pkgs/development/compilers/ligo/default.nix
 @@ -46,6 +46,7 @@ coq.ocamlPackages.buildDunePackage rec {
@@ -104,7 +21,7 @@ index 36ec5bba2e20b..ab61043048af5 100644
      downloadPage = "https://ligolang.org/docs/intro/installation";
 diff --git a/pkgs/development/compilers/ligo/ligo.patch b/pkgs/development/compilers/ligo/ligo.patch
 new file mode 100644
-index 0000000000000..1a076cf18ceed
+index 00000000000..1a076cf18ce
 --- /dev/null
 +++ b/pkgs/development/compilers/ligo/ligo.patch
 @@ -0,0 +1,134 @@
@@ -243,7 +160,7 @@ index 0000000000000..1a076cf18ceed
 +   let start_column = l#start#offset `Byte in
 +   let stop = l#stop#line in
 diff --git a/pkgs/development/ocaml-modules/bap/default.nix b/pkgs/development/ocaml-modules/bap/default.nix
-index 4f87715a74ad9..eaaf621900ad2 100644
+index 4f87715a74a..eaaf621900a 100644
 --- a/pkgs/development/ocaml-modules/bap/default.nix
 +++ b/pkgs/development/ocaml-modules/bap/default.nix
 @@ -1,4 +1,4 @@
@@ -268,7 +185,7 @@ index 4f87715a74ad9..eaaf621900ad2 100644
    preConfigure = ''
      substituteInPlace oasis/elf-loader --replace bitstring.ppx ppx_bitstring
 diff --git a/pkgs/development/ocaml-modules/biocaml/default.nix b/pkgs/development/ocaml-modules/biocaml/default.nix
-index 596ed6161d7b3..b82ec7361791f 100644
+index 596ed6161d7..b82ec736179 100644
 --- a/pkgs/development/ocaml-modules/biocaml/default.nix
 +++ b/pkgs/development/ocaml-modules/biocaml/default.nix
 @@ -4,7 +4,7 @@
@@ -295,7 +212,7 @@ index 596ed6161d7b3..b82ec7361791f 100644
  
    buildInputs = [ ppx_jane ppx_sexp_conv ];
 diff --git a/pkgs/development/ocaml-modules/bistro/default.nix b/pkgs/development/ocaml-modules/bistro/default.nix
-index 348d1bb97d471..43cbd33f738ca 100644
+index 348d1bb97d4..43cbd33f738 100644
 --- a/pkgs/development/ocaml-modules/bistro/default.nix
 +++ b/pkgs/development/ocaml-modules/bistro/default.nix
 @@ -1,10 +1,13 @@
@@ -340,7 +257,7 @@ index 348d1bb97d471..43cbd33f738ca 100644
      ocamlgraph
      ppx_sexp_conv
 diff --git a/pkgs/development/ocaml-modules/cohttp/async.nix b/pkgs/development/ocaml-modules/cohttp/async.nix
-index 060d2c6fb6a86..50c008bf60d87 100644
+index 060d2c6fb6a..50c008bf60d 100644
 --- a/pkgs/development/ocaml-modules/cohttp/async.nix
 +++ b/pkgs/development/ocaml-modules/cohttp/async.nix
 @@ -1,4 +1,6 @@
@@ -374,7 +291,7 @@ index 060d2c6fb6a86..50c008bf60d87 100644
      description = "CoHTTP implementation for the Async concurrency library";
    };
 diff --git a/pkgs/development/ocaml-modules/faraday/async.nix b/pkgs/development/ocaml-modules/faraday/async.nix
-index 666eb684925ce..05b085f92aca6 100644
+index 666eb684925..05b085f92ac 100644
 --- a/pkgs/development/ocaml-modules/faraday/async.nix
 +++ b/pkgs/development/ocaml-modules/faraday/async.nix
 @@ -1,9 +1,14 @@
@@ -394,7 +311,7 @@ index 666eb684925ce..05b085f92aca6 100644
  
    propagatedBuildInputs = [ faraday core async ];
 diff --git a/pkgs/development/ocaml-modules/hack_parallel/default.nix b/pkgs/development/ocaml-modules/hack_parallel/default.nix
-index 122ee2149f3ab..8d1414731f135 100644
+index 122ee2149f3..8d1414731f1 100644
 --- a/pkgs/development/ocaml-modules/hack_parallel/default.nix
 +++ b/pkgs/development/ocaml-modules/hack_parallel/default.nix
 @@ -1,5 +1,5 @@
@@ -420,7 +337,7 @@ index 122ee2149f3ab..8d1414731f135 100644
      description =
 diff --git a/pkgs/development/ocaml-modules/hack_parallel/hack_parallel.patch b/pkgs/development/ocaml-modules/hack_parallel/hack_parallel.patch
 new file mode 100644
-index 0000000000000..174803a348182
+index 00000000000..174803a3481
 --- /dev/null
 +++ b/pkgs/development/ocaml-modules/hack_parallel/hack_parallel.patch
 @@ -0,0 +1,68 @@
@@ -494,7 +411,7 @@ index 0000000000000..174803a348182
 +   let open Unix in
 diff --git a/pkgs/development/ocaml-modules/janestreet/0.15.nix b/pkgs/development/ocaml-modules/janestreet/0.15.nix
 new file mode 100644
-index 0000000000000..bc2f2f24e0a9e
+index 00000000000..bc2f2f24e0a
 --- /dev/null
 +++ b/pkgs/development/ocaml-modules/janestreet/0.15.nix
 @@ -0,0 +1,1000 @@
@@ -1500,7 +1417,7 @@ index 0000000000000..bc2f2f24e0a9e
 +}
 diff --git a/pkgs/development/ocaml-modules/janestreet/bonsai_jsoo_4_0.patch b/pkgs/development/ocaml-modules/janestreet/bonsai_jsoo_4_0.patch
 new file mode 100644
-index 0000000000000..e658ba05ca4c0
+index 00000000000..e658ba05ca4
 --- /dev/null
 +++ b/pkgs/development/ocaml-modules/janestreet/bonsai_jsoo_4_0.patch
 @@ -0,0 +1,13 @@
@@ -1519,7 +1436,7 @@ index 0000000000000..e658ba05ca4c0
 +   and client_width = Js.Optdef.get client_width (Fn.const 0.0)
 diff --git a/pkgs/development/ocaml-modules/janestreet/janePackage_0_15.nix b/pkgs/development/ocaml-modules/janestreet/janePackage_0_15.nix
 new file mode 100644
-index 0000000000000..678599089946d
+index 00000000000..67859908994
 --- /dev/null
 +++ b/pkgs/development/ocaml-modules/janestreet/janePackage_0_15.nix
 @@ -0,0 +1,31 @@
@@ -1556,7 +1473,7 @@ index 0000000000000..678599089946d
 +})
 diff --git a/pkgs/development/ocaml-modules/janestreet/pythonlib.patch b/pkgs/development/ocaml-modules/janestreet/pythonlib.patch
 new file mode 100644
-index 0000000000000..71a32fd0236c3
+index 00000000000..71a32fd0236
 --- /dev/null
 +++ b/pkgs/development/ocaml-modules/janestreet/pythonlib.patch
 @@ -0,0 +1,22 @@
@@ -1583,7 +1500,7 @@ index 0000000000000..71a32fd0236c3
 +       let%bind tuple = List.map es ~f:(fun e -> walk e.desc) |> Or_error.all in
 +       (match tuple with
 diff --git a/pkgs/development/ocaml-modules/phylogenetics/default.nix b/pkgs/development/ocaml-modules/phylogenetics/default.nix
-index 11da66bd76005..1cf9651e6ecc9 100644
+index 11da66bd760..1cf9651e6ec 100644
 --- a/pkgs/development/ocaml-modules/phylogenetics/default.nix
 +++ b/pkgs/development/ocaml-modules/phylogenetics/default.nix
 @@ -1,6 +1,6 @@
@@ -1620,7 +1537,7 @@ index 11da66bd76005..1cf9651e6ecc9 100644
  
    checkInputs = [ alcotest bppsuite ];
 diff --git a/pkgs/development/ocaml-modules/tls/default.nix b/pkgs/development/ocaml-modules/tls/default.nix
-index 81f0a176bfc96..3f45aa919667b 100644
+index 81f0a176bfc..3f45aa91966 100644
 --- a/pkgs/development/ocaml-modules/tls/default.nix
 +++ b/pkgs/development/ocaml-modules/tls/default.nix
 @@ -6,11 +6,11 @@
@@ -1640,7 +1557,7 @@ index 81f0a176bfc96..3f45aa919667b 100644
    minimumOCamlVersion = "4.08";
 diff --git a/pkgs/development/tools/comby/comby.patch b/pkgs/development/tools/comby/comby.patch
 new file mode 100644
-index 0000000000000..ec1f5141985af
+index 00000000000..ec1f5141985
 --- /dev/null
 +++ b/pkgs/development/tools/comby/comby.patch
 @@ -0,0 +1,1025 @@
@@ -2670,7 +2587,7 @@ index 0000000000000..ec1f5141985af
 ++  (source_tree example)
 ++  (source_tree example/src/.ignore-me)))
 diff --git a/pkgs/development/tools/comby/default.nix b/pkgs/development/tools/comby/default.nix
-index cd3251841ad14..34eb2696040dc 100644
+index cd3251841ad..34eb2696040 100644
 --- a/pkgs/development/tools/comby/default.nix
 +++ b/pkgs/development/tools/comby/default.nix
 @@ -26,6 +26,8 @@ let
@@ -2691,7 +2608,7 @@ index cd3251841ad14..34eb2696040dc 100644
          ocamlPackages.mparser
          ocamlPackages.mparser-pcre
 diff --git a/pkgs/tools/misc/flitter/default.nix b/pkgs/tools/misc/flitter/default.nix
-index 49903559c136a..a46b3b72abed5 100644
+index 49903559c13..a46b3b72abe 100644
 --- a/pkgs/tools/misc/flitter/default.nix
 +++ b/pkgs/tools/misc/flitter/default.nix
 @@ -20,11 +20,17 @@ ocamlPackages.buildDunePackage rec {
@@ -2725,7 +2642,7 @@ index 49903559c136a..a46b3b72abed5 100644
      color
 diff --git a/pkgs/tools/misc/flitter/flitter.patch b/pkgs/tools/misc/flitter/flitter.patch
 new file mode 100644
-index 0000000000000..f59b8a22eb676
+index 00000000000..f59b8a22eb6
 --- /dev/null
 +++ b/pkgs/tools/misc/flitter/flitter.patch
 @@ -0,0 +1,13 @@
@@ -2743,7 +2660,7 @@ index 0000000000000..f59b8a22eb676
 +   )
 + 
 diff --git a/pkgs/tools/misc/patdiff/default.nix b/pkgs/tools/misc/patdiff/default.nix
-index dcd06ce1d2b70..2e84d0015d3ae 100644
+index dcd06ce1d2b..2e84d0015d3 100644
 --- a/pkgs/tools/misc/patdiff/default.nix
 +++ b/pkgs/tools/misc/patdiff/default.nix
 @@ -4,8 +4,8 @@ with ocamlPackages;
@@ -2758,7 +2675,7 @@ index dcd06ce1d2b70..2e84d0015d3ae 100644
      description = "File Diff using the Patience Diff algorithm";
    };
 diff --git a/pkgs/tools/typesetting/satysfi/default.nix b/pkgs/tools/typesetting/satysfi/default.nix
-index 89d2724eaad61..d270c46d1ae7f 100644
+index 89d2724eaad..d270c46d1ae 100644
 --- a/pkgs/tools/typesetting/satysfi/default.nix
 +++ b/pkgs/tools/typesetting/satysfi/default.nix
 @@ -50,6 +50,8 @@ in
@@ -2771,10 +2688,10 @@ index 89d2724eaad61..d270c46d1ae7f 100644
  
      buildInputs = [ camlpdf otfm yojson-with-position ] ++ (with ocamlPackages; [
 diff --git a/pkgs/top-level/ocaml-packages.nix b/pkgs/top-level/ocaml-packages.nix
-index 905294b8f8b53..fe460f4a73d36 100644
+index 5083f1733cd..34e8e4a4b9b 100644
 --- a/pkgs/top-level/ocaml-packages.nix
 +++ b/pkgs/top-level/ocaml-packages.nix
-@@ -1476,14 +1476,21 @@ let
+@@ -1535,14 +1535,21 @@ let
      # Jane Street
  
      janePackage =

--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -245,6 +245,7 @@ let
     "xml-light"
     "zmq-lwt"
     "zmq"
+    "labltk"
   ];
 
   darwinIgnores = [

--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -133,6 +133,10 @@ let
     "lablgtk3-gtkspell3"
     "mdx"
 
+
+    "duppy"
+    "taglib"
+    "getopt"
   ];
 
   ocaml412Ignores = [

--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -143,6 +143,10 @@ let
     "taglib"
     "getopt"
     "soundtouch"
+
+    # Incompatible with ppxlib >= 0.27
+    "brisk-reconciler"
+    "flex"
   ];
 
   ocaml412Ignores = [

--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -276,6 +276,8 @@ let
     "ffmpeg-swscale"
     "ffmpeg-swresample"
     "dssi"
+    "inotify"
+    "async_inotify"
 
     # broken on macOS?
     "llvm"

--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -287,7 +287,7 @@ let
 in
 
 rec {
-  inherit ocaml5Ignores ocaml412Ignores;
+  inherit ocaml5Ignores ocaml412Ignores darwinIgnores;
   ocamlCandidates = { pkgs, ocamlVersion, extraIgnores ? [ ] }:
     let
       ocamlPackages = pkgs.ocaml-ng."ocamlPackages_${ocamlVersion}";

--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -133,6 +133,11 @@ let
     "lablgtk3-gtkspell3"
     "mdx"
 
+    "ocaml-freestanding"
+    "mirage-xen"
+    "mirage-bootvar-xen"
+    "mirage-net-xen"
+    "netchannel"
 
     "duppy"
     "taglib"
@@ -254,11 +259,6 @@ let
   ];
 
   darwinIgnores = [
-    "ocaml-freestanding"
-    "mirage-xen"
-    "mirage-bootvar-xen"
-    "mirage-net-xen"
-    "netchannel"
     "ffmpeg"
     "ffmpeg-av"
     "ffmpeg-avdevice"

--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -137,6 +137,7 @@ let
     "duppy"
     "taglib"
     "getopt"
+    "soundtouch"
   ];
 
   ocaml412Ignores = [

--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -155,6 +155,7 @@ let
     "async_inotify"
     "async_smtp"
     "pgsolver"
+    "tcslib"
   ];
 
   ocaml412Ignores = [
@@ -297,7 +298,6 @@ let
     "mm"
     "pulseaudio"
 
-    "tcslib"
     "gstreamer"
   ];
 

--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -70,37 +70,12 @@ let
     # broken since 4.12
     "ocaml_extlib-1-7-7"
 
-    # unavailable on macOS
-    "ocaml-freestanding"
-    "mirage-xen"
-    "mirage-bootvar-xen"
-    "mirage-net-xen"
-    "netchannel"
-    "ffmpeg"
-    "ffmpeg-av"
-    "ffmpeg-avdevice"
-    "ffmpeg-avfilter"
-    "ffmpeg-avutil"
-    "ffmpeg-avcodec"
-    "ffmpeg-swscale"
-    "ffmpeg-swresample"
-    "dssi"
-
     # doesn't work with my fork of http/af
     "paf"
     "paf-le"
     "paf-cohttp"
     "git-paf"
     "irmin-mirage-git"
-
-    # broken on macOS?
-    "llvm"
-    "ocaml_libvirt"
-    "labltk"
-    "bjack"
-    "async_inotify"
-    "async_smtp"
-    "pgsolver"
 
     # broken with ppxlib 0.23
     "elpi"
@@ -267,6 +242,37 @@ let
     "zmq-lwt"
     "zmq"
   ];
+
+  darwinIgnores = [
+    "ocaml-freestanding"
+    "mirage-xen"
+    "mirage-bootvar-xen"
+    "mirage-net-xen"
+    "netchannel"
+    "ffmpeg"
+    "ffmpeg-av"
+    "ffmpeg-avdevice"
+    "ffmpeg-avfilter"
+    "ffmpeg-avutil"
+    "ffmpeg-avcodec"
+    "ffmpeg-swscale"
+    "ffmpeg-swresample"
+    "dssi"
+
+    # broken on macOS?
+    "llvm"
+    "ocaml_libvirt"
+    "labltk"
+    "bjack"
+    "async_inotify"
+    "async_smtp"
+    "pgsolver"
+
+    "alsa"
+    "ladspa"
+    "mm"
+  ];
+
 in
 
 rec {
@@ -274,7 +280,10 @@ rec {
   ocamlCandidates = { pkgs, ocamlVersion, extraIgnores ? [ ] }:
     let
       ocamlPackages = pkgs.ocaml-ng."ocamlPackages_${ocamlVersion}";
-      ignoredPackages = baseIgnoredPackages ++ extraIgnores;
+      ignoredPackages =
+        baseIgnoredPackages ++
+        lib.optionals stdenv.isDarwin darwinIgnores ++
+        extraIgnores;
     in
     lib.filterAttrs
       (n: v:

--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -147,6 +147,9 @@ let
     # Incompatible with ppxlib >= 0.27
     "brisk-reconciler"
     "flex"
+    "rebez"
+    "reenv"
+    "reperf"
   ];
 
   ocaml412Ignores = [
@@ -183,6 +186,7 @@ let
     "incr_dom"
     "inifiles"
     "inotify"
+    "async_inotify"
     "irmin-git"
     "js_of_ocaml-compiler"
     "js_of_ocaml-lwt"
@@ -278,7 +282,6 @@ let
     "ocaml_libvirt"
     "labltk"
     "bjack"
-    "async_inotify"
     "async_smtp"
     "pgsolver"
 

--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -129,6 +129,10 @@ let
     "pg-solver"
     "cpdf"
 
+    # Broken by python transitive dependencies?
+    "lablgtk3-gtkspell3"
+    "mdx"
+
   ];
 
   ocaml412Ignores = [
@@ -271,6 +275,7 @@ let
     "alsa"
     "ladspa"
     "mm"
+    "pulseaudio"
   ];
 
 in

--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -150,6 +150,11 @@ let
     "rebez"
     "reenv"
     "reperf"
+
+    "inotify"
+    "async_inotify"
+    "async_smtp"
+    "pgsolver"
   ];
 
   ocaml412Ignores = [
@@ -185,8 +190,6 @@ let
     "imagelib"
     "incr_dom"
     "inifiles"
-    "inotify"
-    "async_inotify"
     "irmin-git"
     "js_of_ocaml-compiler"
     "js_of_ocaml-lwt"
@@ -251,7 +254,6 @@ let
     "stdint"
     "tar-unix"
     "tar"
-    "tcslib"
     "telegraml"
     "twt"
     "uecc"
@@ -283,21 +285,20 @@ let
     "ffmpeg-swscale"
     "ffmpeg-swresample"
     "dssi"
-    "inotify"
-    "async_inotify"
 
     # broken on macOS?
     "llvm"
     "ocaml_libvirt"
     "labltk"
     "bjack"
-    "async_smtp"
-    "pgsolver"
 
     "alsa"
     "ladspa"
     "mm"
     "pulseaudio"
+
+    "tcslib"
+    "gstreamer"
   ];
 
 in

--- a/ci/filter.nix
+++ b/ci/filter.nix
@@ -264,6 +264,13 @@ let
     "zmq-lwt"
     "zmq"
     "labltk"
+
+    "ocamlformat"
+    "ocamlformat-rpc_0_20_0"
+    "ocamlformat-rpc_0_20_1"
+    "ocamlformat-rpc_0_21_0"
+    "ocamlformat-rpc"
+
   ];
 
   darwinIgnores = [

--- a/ci/hydra.nix
+++ b/ci/hydra.nix
@@ -1,7 +1,8 @@
 { pkgs, system }:
 let
   filter = pkgs.callPackage ./filter.nix { };
-  extraIgnores = [ ];
+  isDarwin = system == "aarch64-darwin" || system == "x86_64-darwin";
+  extraIgnores = if isDarwin then filter.darwinIgnores else [ ];
 in
 
 with filter;
@@ -11,16 +12,15 @@ with filter;
   build_4_14 = ocamlCandidates { inherit pkgs extraIgnores; ocamlVersion = "4_14"; };
   build_5_00 = ocamlCandidates { inherit pkgs; ocamlVersion = "5_00"; extraIgnores = extraIgnores ++ ocaml5Ignores; };
 
-  /*
-    arm64_4_13 = (if system == "x86_64-linux" then
+  arm64_4_13 = (if system == "x86_64-linux" then
     crossTarget pkgs.pkgsCross.aarch64-multiplatform-musl "4_13"
-    else
+  else
     { });
 
-    musl_4_13 = (if system == "x86_64-linux" then
+  musl_4_13 = (if system == "x86_64-linux" then
     crossTarget pkgs.pkgsCross.musl64 "4_13"
-    else
+  else
     { }
-    );
-  */
+  );
+
 }

--- a/cross/ocaml.nix
+++ b/cross/ocaml.nix
@@ -33,9 +33,13 @@ let
 
   getNativeOCamlPackages = osuper:
     let
-      version = lib.stringAsChars
-        (x: if x == "." then "_" else x)
-        (builtins.substring 0 4 osuper.ocaml.version);
+      version =
+        if lib.hasPrefix "5." osuper.ocaml.version
+        then "5_00"
+        else
+          lib.stringAsChars
+            (x: if x == "." then "_" else x)
+            (builtins.substring 0 4 osuper.ocaml.version);
 
     in
     buildPackages.ocaml-ng."ocamlPackages_${version}";

--- a/cross/ocaml.nix
+++ b/cross/ocaml.nix
@@ -187,8 +187,8 @@ in
         for ARG in "$@"; do NEW_ARGS="$NEW_ARGS \"$ARG\""; done
         eval "${camlBin} $NEW_ARGS"
       '';
-      ocamlcHostWrapper = genWrapper "ocamlcHost.wrapper" "${natocaml}/bin/ocamlc.opt -I ${natocaml}/lib/ocaml -I ${natocaml}/lib/ocaml/stublibs -I $BUILD_ROOT/otherlibs/unix -nostdlib ";
-      ocamloptHostWrapper = genWrapper "ocamloptHost.wrapper" "${natocaml}/bin/ocamlopt.opt -I ${natocaml}/lib/ocaml -I $BUILD_ROOT/otherlibs/unix -nostdlib ";
+      ocamlcHostWrapper = genWrapper "ocamlcHost.wrapper" "${natocaml}/bin/ocamlc.opt -I ${natocaml}/lib/ocaml -I ${natocaml}/lib/ocaml/stublibs -I +unix -nostdlib ";
+      ocamloptHostWrapper = genWrapper "ocamloptHost.wrapper" "${natocaml}/bin/ocamlopt.opt -I ${natocaml}/lib/ocaml -I +unix -nostdlib ";
 
       ocamlcTargetWrapper = genWrapper "ocamlcTarget.wrapper" "$BUILD_ROOT/ocamlc.opt -I $BUILD_ROOT/stdlib -I $BUILD_ROOT/otherlibs/unix -I ${natocaml}/lib/ocaml/stublibs -nostdlib ";
       ocamloptTargetWrapper = genWrapper "ocamloptTarget.wrapper" "$BUILD_ROOT/ocamlopt.opt -I $BUILD_ROOT/stdlib -I $BUILD_ROOT/otherlibs/unix -nostdlib ";
@@ -242,7 +242,6 @@ in
               CAMLOPT="${ocamloptHostWrapper}/bin/ocamloptHost.wrapper"
 
               make_caml \
-                BUILD_ROOT="$PWD" \
                 NATDYNLINK="$NATDYNLINK" NATDYNLINKOPTS="$NATDYNLINKOPTS" \
                 "$@"
             }

--- a/cross/ocaml.nix
+++ b/cross/ocaml.nix
@@ -187,8 +187,8 @@ in
         for ARG in "$@"; do NEW_ARGS="$NEW_ARGS \"$ARG\""; done
         eval "${camlBin} $NEW_ARGS"
       '';
-      ocamlcHostWrapper = genWrapper "ocamlcHost.wrapper" "${natocaml}/bin/ocamlc.opt -I ${natocaml}/lib/ocaml -I ${natocaml}/lib/ocaml/stublibs -nostdlib ";
-      ocamloptHostWrapper = genWrapper "ocamloptHost.wrapper" "${natocaml}/bin/ocamlopt.opt -I ${natocaml}/lib/ocaml -nostdlib ";
+      ocamlcHostWrapper = genWrapper "ocamlcHost.wrapper" "${natocaml}/bin/ocamlc.opt -I ${natocaml}/lib/ocaml -I ${natocaml}/lib/ocaml/stublibs -I $BUILD_ROOT/otherlibs/unix -nostdlib ";
+      ocamloptHostWrapper = genWrapper "ocamloptHost.wrapper" "${natocaml}/bin/ocamlopt.opt -I ${natocaml}/lib/ocaml -I $BUILD_ROOT/otherlibs/unix -nostdlib ";
 
       ocamlcTargetWrapper = genWrapper "ocamlcTarget.wrapper" "$BUILD_ROOT/ocamlc.opt -I $BUILD_ROOT/stdlib -I $BUILD_ROOT/otherlibs/unix -I ${natocaml}/lib/ocaml/stublibs -nostdlib ";
       ocamloptTargetWrapper = genWrapper "ocamloptTarget.wrapper" "$BUILD_ROOT/ocamlopt.opt -I $BUILD_ROOT/stdlib -I $BUILD_ROOT/otherlibs/unix -nostdlib ";
@@ -242,6 +242,7 @@ in
               CAMLOPT="${ocamloptHostWrapper}/bin/ocamloptHost.wrapper"
 
               make_caml \
+                BUILD_ROOT="$PWD" \
                 NATDYNLINK="$NATDYNLINK" NATDYNLINKOPTS="$NATDYNLINKOPTS" \
                 "$@"
             }

--- a/cross/ocaml.nix
+++ b/cross/ocaml.nix
@@ -11,15 +11,16 @@
 { lib, buildPackages, writeText, writeScriptBin, stdenv, bash }:
 let
   __mergeInputs = acc: names: attrs:
-    let ret =
-      lib.foldl' (acc: x: acc // { "${x.name}" = x; })
-        { }
-        (builtins.concatMap
-          (name:
-            builtins.filter
-              lib.isDerivation
-              (lib.concatLists (lib.catAttrs name attrs)))
-          names);
+    let
+      ret =
+        lib.foldl' (acc: x: acc // { "${x.name}" = x; })
+          { }
+          (builtins.concatMap
+            (name:
+              builtins.filter
+                lib.isDerivation
+                (lib.concatLists (lib.catAttrs name attrs)))
+            names);
     in
     if ret == { } then acc
     else

--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1654201406,
-        "narHash": "sha256-3lDelbEvTt5QufWJ7CTVWcf56HmLYotacc6qvrR3VDQ=",
+        "lastModified": 1655838478,
+        "narHash": "sha256-SWxu/sJffp/kcy+wT8mLZpnTIXNP3a9qs0O1IRArOLo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "98e0b747df49e3edd1aa2c4e7fcc98361a17b09f",
+        "rev": "170a413797473733c5be0dd08cdbbab0e39b8aae",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "98e0b747df49e3edd1aa2c4e7fcc98361a17b09f",
+        "rev": "170a413797473733c5be0dd08cdbbab0e39b8aae",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "ocaml-packages-overlay";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=98e0b747df49e3edd1aa2c4e7fcc98361a17b09f";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=170a413797473733c5be0dd08cdbbab0e39b8aae";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -36,11 +36,12 @@
         [ "x86_64-linux" "aarch64-darwin" ]);
 
       makePkgs = { system, extraOverlays ? [ ], ... }@attrs:
-        let pkgs = import nixpkgs ({
-          inherit system;
-          overlays = [ self.overlays.${system}.default ];
-          config.allowUnfree = true;
-        } // attrs);
+        let
+          pkgs = import nixpkgs ({
+            inherit system;
+            overlays = [ self.overlays.${system}.default ];
+            config.allowUnfree = true;
+          } // attrs);
         in
           /*
             You might read https://nixos.org/manual/nixpkgs/stable/#sec-overlays-argument and want to change this

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1153,7 +1153,7 @@ with oself;
   });
 
   ppx_cstubs = osuper.ppx_cstubs.overrideAttrs (o: {
-    buildInputs = o.buildInputs ++ [ osuper.findlib ];
+    buildInputs = o.buildInputs ++ [ findlib ];
   });
 
   ppx_jsx_embed = callPackage ./ppx_jsx_embed { };

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1164,16 +1164,9 @@ with oself;
 
   ppxlib = osuper.ppxlib.overrideAttrs (_: {
     src = builtins.fetchurl {
-      url = https://github.com/ocaml-ppx/ppxlib/releases/download/0.26.0/ppxlib-0.26.0.tbz;
-      sha256 = "1zbyh6pr6fih2c1p6gs8y0q0ag1kzs41z4pyama96qsqx9kpn4b3";
+      url = https://github.com/ocaml-ppx/ppxlib/releases/download/0.27.0/ppxlib-0.27.0.tbz;
+      sha256 = "0qlcnb2aas6h69zgjbygjhmw9gvna4iwa3hfh9rnmzbg3l99cjvn";
     };
-    patches = [
-      # OCaml 5.00 support
-      (fetchpatch {
-        url = https://github.com/patricoferris/ppxlib/commit/91c39e958fca1dabf16f64dc7699ace7752f0014.patch;
-        sha256 = "sha256-RVHA0UAJwB0DbxRrEVqtBPu8TRAxxazg3X+whyjq3Uk=";
-      })
-    ];
     propagatedBuildInputs = [
       ocaml-compiler-libs
       ppx_derivers
@@ -1211,8 +1204,8 @@ with oself;
 
   ppx_deriving_yojson = osuper.ppx_deriving_yojson.overrideAttrs (o: {
     src = builtins.fetchurl {
-      url = https://github.com/ocaml-ppx/ppx_deriving_yojson/archive/64c3af9.tar.gz;
-      sha256 = "1xzk0z6304ivm2lfrmd7mqxnirsimbq89ds3fkh6dvjyysav2mqi";
+      url = https://github.com/ocaml-ppx/ppx_deriving_yojson/archive/c048f5d.tar.gz;
+      sha256 = "1c6fvcj2s0jjar9g3f96v7l32n05qg1mdfhj6sixvq535lm5gw0a";
     };
     propagatedBuildInputs = [ ppxlib ppx_deriving yojson ];
   });

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -815,14 +815,6 @@ with oself;
   melange = callPackage ./melange { };
   melange-compiler-libs = callPackage ./melange/compiler-libs.nix { };
 
-  # This overrides Menhir too.
-  menhirLib = osuper.menhirLib.overrideAttrs (_: {
-    src = builtins.fetchurl {
-      url = https://gitlab.inria.fr/fpottier/menhir/-/archive/e5c3087028286016ed72880fe5e702077b28441a.tar.gz;
-      sha256 = "0pis7mghrnl5ahqv3gm0ybjb1032ifixsnfz5skg6n8jl4pggi2w";
-    };
-  });
-
   dot-merlin-reader = callPackage ./merlin/dot-merlin.nix { };
   merlin = callPackage ./merlin { };
 
@@ -1003,13 +995,6 @@ with oself;
     };
     propagatedBuildInputs = [ cmdliner ez_subst ocplib_stuff ];
   };
-
-  ocaml-migrate-parsetree-2 = osuper.ocaml-migrate-parsetree-2.overrideAttrs (_: {
-    postPatch = ''
-      substituteInPlace src/config/gen.ml --replace \
-        '| (4, 14) -> "414"'  '| (4, 14) -> "414" | (5, 0) -> "500"'
-    '';
-  });
 
   ocaml-migrate-types = callPackage ./ocaml-migrate-types { };
   typedppxlib = callPackage ./typedppxlib { };
@@ -1682,16 +1667,6 @@ with oself;
       sha256 = "179f1iz504l008b3p3d9q2nj44wv7y31pc997x32m6aq1j2lfip3";
     };
   });
-
-  ppx_yojson_conv_lib = janePackage {
-    pname = "ppx_yojson_conv_lib";
-    version = "0.15.0";
-    hash = "sha256-Hpg4AKAe7Q5P5UkBpH+5l1nZbIVA2Dr1Q30D4zkrjGo=";
-    propagatedBuildInputs = [ yojson ];
-    meta = {
-      description = "Yojson Deriver PPX";
-    };
-  };
 
   ppx_yojson_conv = janePackage {
     pname = "ppx_yojson_conv";

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -637,13 +637,12 @@ with oself;
 
   iter = osuper.iter.overrideAttrs (o: {
     src = builtins.fetchurl {
-      url = https://github.com/c-cube/iter/archive/8be24288.tar.gz;
-      sha256 = "0hkgia50lqwh13b5f0515z2w17q8pqd3nrnza76ns9h34qag55l9";
+      url = https://github.com/c-cube/iter/archive/a3b34263.tar.gz;
+      sha256 = "0jfb7aw1fv2y5skcv0gc74j37fy2k22j87fqs6fjhpw0dw2si0lr";
     };
-    postPatch = ''
-      substituteInPlace "src/dune" --replace "(libraries " "(libraries camlp-streams "
-    '';
-    propagatedBuildInputs = o.propagatedBuildInputs ++ [ camlp-streams ];
+
+    # MDX has some broken python transitive deps
+    doCheck = false;
   });
 
   itv-tree = buildDunePackage {
@@ -1224,6 +1223,7 @@ with oself;
 
   ppx_tools = callPackage ./ppx_tools { };
 
+  printbox = disableTests osuper.printbox;
   printbox-text = osuper.printbox-text.overrideAttrs (_: {
     src = builtins.fetchurl {
       url = https://github.com/c-cube/printbox/archive/refs/tags/v0.6.tar.gz;
@@ -1466,6 +1466,8 @@ with oself;
       sha256 = "1qx89nzwv9qx6zw9xbrzlsvpmxwb30iji41kdw10x40ylwfnra4x";
     };
   });
+
+  yaml = disableTests osuper.yaml;
 
   yojson_2 = osuper.yojson.overrideAttrs (o: {
     src = builtins.fetchurl {

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1348,6 +1348,7 @@ with oself;
     preConfigure = ''
       echo '(using menhir 2.1)' >> ./dune-project
     '';
+    patches = [ ];
   });
 
   tezos-protocol-compiler = osuper.tezos-protocol-compiler.overrideAttrs (o: {

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -24,10 +24,11 @@ let
   nativeCairo = cairo;
   lmdb-pkg = lmdb;
   pkg-config-script =
-    let pkg-config-pkg =
-      if stdenv.cc.targetPrefix == ""
-      then "${pkg-config}/bin/pkg-config"
-      else "${stdenv.cc.targetPrefix}pkg-config";
+    let
+      pkg-config-pkg =
+        if stdenv.cc.targetPrefix == ""
+        then "${pkg-config}/bin/pkg-config"
+        else "${stdenv.cc.targetPrefix}pkg-config";
     in
     writeScriptBin "pkg-config" ''
       #!${stdenv.shell}

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1538,6 +1538,10 @@ with oself;
   });
 
   core_unix = osuper.core_unix.overrideAttrs (o: {
+    src = builtins.fetchurl {
+      url = https://github.com/janestreet/core_unix/archive/65a25ec0.tar.gz;
+      sha256 = "1fr223k0bwpmavqr7glj1ljs3ybgg6j4mvs53d7kcj7kc1ngz0rm";
+    };
     # https://github.com/janestreet/core_unix/issues/2
     patches =
       if lib.versionAtLeast ocaml.version "5.00" then

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1680,7 +1680,7 @@ with oself;
     };
   });
 
-  ppx_yojson_conv = janePackage {
+  ppx_yojson_conv = (janePackage {
     pname = "ppx_yojson_conv";
     version = "0.15.0";
     hash = "sha256-FGtReLkdI9EnD6sPsMQSv5ipfDyY6z5fIkjqH+tie48=";
@@ -1688,8 +1688,12 @@ with oself;
     meta = {
       description = "Yojson Deriver PPX";
     };
-  };
-
+  }).overrideAttrs (_: {
+    src = builtins.fetchurl {
+      url = https://github.com/janestreet/ppx_yojson_conv/archive/ea556c6.tar.gz;
+      sha256 = "0r4sd781ff1bjpw9hwim4i4q3sp30w3x4gz854mz596w5d1cl1xk";
+    };
+  });
 
   sexp_pretty = osuper.sexp_pretty.overrideAttrs (_: {
     patches =

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -641,6 +641,7 @@ with oself;
       sha256 = "0jfb7aw1fv2y5skcv0gc74j37fy2k22j87fqs6fjhpw0dw2si0lr";
     };
 
+    propagatedBuildInputs = o.propagatedBuildInputs ++ [ seq ];
     # MDX has some broken python transitive deps
     doCheck = false;
   });

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -408,10 +408,10 @@ with oself;
   dune_2 = dune_3;
 
   dune_3 = osuper.dune_3.overrideAttrs (_: {
-    version = "3.2.0";
+    version = "3.3.1";
     src = builtins.fetchurl {
-      url = https://github.com/ocaml/dune/releases/download/3.2.0/chrome-trace-3.2.0.tbz;
-      sha256 = "1g6m3a5b1nhvrxw5agzmng7ayy1rwbib56x8dyr1xvbrmvkbq7xx";
+      url = https://github.com/ocaml/dune/releases/download/3.3.1/dune-3.3.1.tbz;
+      sha256 = "1q82ap6xq93cn5pkwjjbzk9c9r7kcghlk7dryasvl4py3d4q0344";
     };
   });
 
@@ -471,6 +471,17 @@ with oself;
     };
     propagatedBuildInputs = [ rresult astring ocplib-endian camlzip result ];
   };
+
+  findlib = osuper.findlib.overrideAttrs (_: {
+    src = builtins.fetchurl {
+      url = https://github.com/ocaml/ocamlfind/archive/refs/tags/findlib-1.9.5.tar.gz;
+      sha256 = "1dydivj0fs1snxss47fi84kgk1bf2cfbwgwv7j4lrzlr0xqli3xa";
+    };
+    patches = [
+      "${nixpkgs}/pkgs/development/tools/ocaml/findlib/ldconf.patch"
+      ./findlib_install_topfind.patch
+    ];
+  });
 
   fix = osuper.fix.overrideAttrs (_: {
     src = builtins.fetchurl {
@@ -701,6 +712,13 @@ with oself;
       '' else "";
   });
 
+  lambda-term = osuper.lambda-term.overrideAttrs (_: {
+    src = builtins.fetchurl {
+      url = https://github.com/ocaml-community/lambda-term/archive/d68d2fd21554b16b6968b943566a21f62614f072.tar.gz;
+      sha256 = "1iiaywjk1s9kv4344b60gy495kkp9i5v3lsf5zk03awxnq08habv";
+    };
+  });
+
   lmdb = buildDunePackage {
     pname = "lmdb";
     version = "1.0";
@@ -746,8 +764,8 @@ with oself;
     '';
 
     src = builtins.fetchurl {
-      url = https://github.com/ocsigen/lwt/archive/654952b62.tar.gz;
-      sha256 = "16z8c2x0asj24rjrgv2wa4bywxq9f3zlh0ha8flfaw18p95sgw2r";
+      url = https://github.com/ocsigen/lwt/archive/449f1809.tar.gz;
+      sha256 = "1hyz276ls5wzkj0jh34jfilr0a2ndyjrw2d8i518z91bsm1pd2cl";
     };
   });
 

--- a/ocaml/findlib_install_topfind.patch
+++ b/ocaml/findlib_install_topfind.patch
@@ -1,0 +1,15 @@
+diff --git a/src/findlib/Makefile b/src/findlib/Makefile
+index 84514b6..c73dd5f 100644
+--- a/src/findlib/Makefile
++++ b/src/findlib/Makefile
+@@ -123,8 +123,8 @@ clean:
+ install: all
+ 	$(INSTALLDIR) "$(DESTDIR)$(prefix)$(OCAML_SITELIB)/$(NAME)"
+ 	$(INSTALLDIR) "$(DESTDIR)$(prefix)$(OCAMLFIND_BIN)"
+-	$(INSTALLDIR) "$(DESTDIR)$(prefix)$(OCAML_CORE_STDLIB)"
+-	test $(INSTALL_TOPFIND) -eq 0 || $(INSTALLFILE) topfind "$(DESTDIR)$(prefix)$(OCAML_CORE_STDLIB)/"
++	$(INSTALLDIR) "$(DESTDIR)$(prefix)$(OCAML_SITELIB)"
++	test $(INSTALL_TOPFIND) -eq 0 || $(INSTALLFILE) topfind "$(DESTDIR)$(prefix)$(OCAML_SITELIB)/"
+ 	files=`$(SH) $(TOP)/tools/collect_files $(TOP)/Makefile.config \
+ 	findlib.cmi findlib.mli findlib.cma findlib.cmxa findlib$(LIB_SUFFIX) findlib.cmxs \
+ 	findlib_config.cmi findlib_config.ml topfind.cmi topfind.mli \

--- a/ocaml/graphql_ppx/default.nix
+++ b/ocaml/graphql_ppx/default.nix
@@ -5,15 +5,15 @@ buildDunePackage {
   version = "1.2.3";
 
   src = builtins.fetchurl {
-    url = https://github.com/teamwalnut/graphql-ppx/archive/refs/tags/v1.2.3.tar.gz;
-    sha256 = "0jwaf4rac2c9n4k01hf3krjklflhld0z0wynh32666yav10h4zdb";
+    url = https://github.com/teamwalnut/graphql-ppx/archive/4a1fbfebf9.tar.gz;
+    sha256 = "0d1kadwgdsdfma12f6rfssy8qqk8nkcx7650wvr53y8ck0yr3kqs";
   };
 
   nativeBuildInputs = [ cppo ];
   propagatedBuildInputs = [ yojson ppxlib reason ];
 
   postInstall = ''
-    mkdir $out/lib_bucklescript
-    cp -r ./package.json ./bsconfig.json ./bucklescript $out/lib_bucklescript
+    mkdir -p $out/lib-runtime
+    cp -r ./package.json ./bsconfig.json ./rescript-runtime $out/lib-runtime
   '';
 }

--- a/ocaml/merlin/dot-merlin.nix
+++ b/ocaml/merlin/dot-merlin.nix
@@ -22,7 +22,6 @@ buildDunePackage {
   src =
     if (lib.versionOlder "5.00" ocaml.version)
     then
-
       builtins.fetchurl
         {
           url = https://github.com/ocaml/merlin/archive/fce8fb220c6677a4e1f1677efa2e5b5b13f12254.tar.gz;

--- a/ocaml/mongo/bson.nix
+++ b/ocaml/mongo/bson.nix
@@ -3,8 +3,8 @@
 buildDunePackage {
   pname = "bson";
   src = builtins.fetchurl {
-    url = https://github.com/anmonteiro/ocaml-mongodb/archive/f491384652eaf24e423204ae79f590bb90fb6506.tar.gz;
-    sha256 = "1anklswasz38xyn7k5fznj5985banfkf84si1ajjycx62xqlnr3a";
+    url = https://github.com/anmonteiro/ocaml-mongodb/archive/9062e42.tar.gz;
+    sha256 = "1yggvmv6a9njyx7na3967fkab0icl7iwnq6b7yhli4sndbgid1y2";
   };
   version = "0.0.1-dev";
 

--- a/ocaml/overlay-ocaml-packages.nix
+++ b/ocaml/overlay-ocaml-packages.nix
@@ -34,12 +34,12 @@ let
 
       ocamlPackages_5_00 = newOCamlScope {
         major_version = "5";
-        minor_version = "00";
+        minor_version = "0";
         patch_version = "0+trunk";
         hardeningDisable = [ "strictoverflow" ];
         src = builtins.fetchurl {
-          url = https://github.com/ocaml/ocaml/archive/c77dcd47cc729ca6f1ec358c9f07f34fe948ee86.tar.gz;
-          sha256 = "1949s06qwdfaya43vc3ws154f3hp0qx8fx2qf2s88v4w6h04gzrw";
+          url = https://github.com/ocaml/ocaml/archive/29f77d0.tar.gz;
+          sha256 = "1rgkq71ncs2lv75vq4im79k32w24ya7jn1r0flma8k3caw87d2qv";
         };
       };
 

--- a/ocaml/reason/default.nix
+++ b/ocaml/reason/default.nix
@@ -16,8 +16,8 @@ buildDunePackage rec {
   version = "3.8.0";
 
   src = builtins.fetchurl {
-    url = https://github.com/reasonml/reason/archive/a93c4c3.tar.gz;
-    sha256 = "09bs2vkq4rkxv4z564vr4d3d6hd23b118ma72gkmrbc7ldxhj972";
+    url = https://github.com/reasonml/reason/archive/b3aa77b.tar.gz;
+    sha256 = "1vlani83cvfz1jikj35dcwgih2bwixsrcczv5rw81f5j8yzy46an";
   };
 
 

--- a/ocaml/reason/default.nix
+++ b/ocaml/reason/default.nix
@@ -16,8 +16,8 @@ buildDunePackage rec {
   version = "3.8.0";
 
   src = builtins.fetchurl {
-    url = https://github.com/reasonml/reason/archive/b3aa77b.tar.gz;
-    sha256 = "1vlani83cvfz1jikj35dcwgih2bwixsrcczv5rw81f5j8yzy46an";
+    url = https://github.com/reasonml/reason/archive/3f43382.tar.gz;
+    sha256 = "1zz5xwh7bw2fv6cmxnknd5i6zfcqflfvqy9zcc43giz6ygcl498x";
   };
 
 

--- a/static/ocaml.nix
+++ b/static/ocaml.nix
@@ -24,17 +24,17 @@ let
     });
 in
 (oself: osuper:
-  lib.mapAttrs
-    (_: p:
-      if p ? overrideAttrs then
-        fixOCamlPackage p
-      else p)
-    osuper // {
-    ocaml = fixOCaml osuper.ocaml;
+lib.mapAttrs
+  (_: p:
+    if p ? overrideAttrs then
+      fixOCamlPackage p
+    else p)
+  osuper // {
+  ocaml = fixOCaml osuper.ocaml;
 
-    zarith = osuper.zarith.overrideDerivation (o: {
-      configureFlags = o.configureFlags ++ [
-        "-prefixnonocaml ${o.stdenv.hostPlatform.config}-"
-      ];
-    });
-  })
+  zarith = osuper.zarith.overrideDerivation (o: {
+    configureFlags = o.configureFlags ++ [
+      "-prefixnonocaml ${o.stdenv.hostPlatform.config}-"
+    ];
+  });
+})


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href=https://github.com/NixOS/nixpkgs/commit/1bdc32f97002440304c620ef6f1dadc49ab9a6b1><pre>ocaml-ng.ocamlPackages_4_00_1.ocaml, ocaml-ng.ocamlPackages_4_08.ocaml: add -fcommon workaround

Workaround build failure on -fno-common toolchains like upstream
gcc-10. Otherwise build fails as:

    $ nix build --impure --expr \'with import ./. {}; ocaml-ng.ocamlPackages_4_00_1.ocaml.overrideAttrs (oa: {   NIX_CFLAGS_COMPILE = (["-fno-common"] ++ [oa.NIX_CFLAGS_COMPILE or ""]); })\'
    ...
    > ld: libcamlrun.a(startup.o):(.bss+0x800): multiple definition of `caml_code_fragments_table\'; libcamlrun.a(backtrace.o):(.bss+0x20): first defined here
    > collect2: error: ld returned 1 exit status</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/81008f02c420a34097f2c612edf08cf298c695c5><pre>ocamlPackages.menhir: 20211128 → 20220210</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/e5b2c5f447ff3cadbbaff89ef2d547eee07c250d><pre>ocamlPackages.alsa: init at 3.0.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/e5031b839b07a5432f12fd2505339c7cbdaabfd4><pre>ocamlPackages.gstreamer: init at 0.3.1</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/754433d82a58d18a3c492cc84b4eae794766d648><pre>ocamlPackages.portaudio: init at 0.2.3</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7ed016627f9b7c3a0ab068cb526ad37ec2f8bcc7><pre>ocamlPackages.pulseaudio: init at 0.1.5</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/f3c53f430f18e5c0a3c5d38669db5b817aabf2a2><pre>ocamlPackages.dtools: init at 0.4.4</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/85665ca9d489a6cc1352f9c16abe3106ea2f0d2d><pre>ocamlPackages.duppy: init at 0.9.2</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/11208c64001f7c0c0073b6fd47c21bd9b1aff8aa><pre>ocamlPackages.lo: init at 0.2.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/60ff8d2306663d08621247b9416351a36183492e><pre>ocamlPackages.magic: init at 0.7.3</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/5e76c6961d1b992046781c21c7d7dfd5df60d013><pre>ocamlPackages.ao: init at 0.2.4</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/fbfd28e8ac8585dd9cb2e5cadfdfaf8597f9ad0a><pre>ocamlPackages.mad: init at 0.5.2</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/5a862299e02b49126d44844e60d343c74eff8a9f><pre>ocamlPackages.mm: init at 0.8.1</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/50cac6ed5ed534f8a1539349863599ade91295e7><pre>ocamlPackages.unix-errno: init at 0.6.1</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/cb26845685076ac02be9b9972a712d500fec9384><pre>ocamlPackages.posix-time2: init at 2.0.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/ab7173f6db30fcffe01a23d85138449fa990cabf><pre>ocamlPackages.srt: 0.1.1 -> 0.2.1</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/18aaa33f07a5193c18448d6f382a3c6662842ffc><pre>ocamlPackages.elpi: 1.14.1 → 1.15.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/f7373e4932d73da83f6c59b8d28bf53faf97ca2f><pre>ocamlPackages.elpi: 1.15.0 → 1.15.2

Co-authored-by: Pierre Roux <pierre.roux@onera.fr></pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/174c0a086e60e3ea2ac21077200145e054eda0c8><pre>ocamlPackages.cry: init at 0.6.5</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/866dbd9d4208a63df2cb6a2e4ae54ceeb7195472><pre>ocamlPackages.faad: init at 0.5.1</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/430b2bc83b3c67526f134fc06afc977dffb061a4><pre>ocamlPackages.lame: init at 0.3.6</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/f34e9c30025fb1300a25e53c2c9aa794ad377af4><pre>ocamlPackages.frei0r: init at 0.1.2</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/89a381788e217161d610030b80f3f79e26faa7ef><pre>ocamlPackages.soundtouch: init at 0.1.9</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/c035e81dacae0f74a5c81e08aefa904e8c418aee><pre>ocamlPackages.taglib: init at 0.3.9</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/592f58a1900b95d814e545f38c95ec4c613f5075><pre>ocamlPackages.lilv: init at 0.1.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/b64a90b182c7bd96a72fda511809ab65a50588f6><pre>ocamlPackages.ocurl: 0.9.1 -> 0.9.2</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/3a5d3c73c78cb63df07fce947a2fe5e6058069a3><pre>ocamlPackages.wasm: 1.1.1 → 2.0.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/1f31dbf1ec76d986d56c7c5391245e7bf0ba44d6><pre>ocamlPackages.cry: 0.6.5 -> 0.6.7</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/69443b19b8aa329b7f415e2ed6254c1c916254f3><pre>ocamlPackages.tsort: 2.0.0 -> 2.1.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/f22126fe9a21cb2c19f95a4c178092371ea37b4d><pre>ocamlPackages.ppx_yojson_conv_lib: 0.14.0 -> 0.15.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/ab4868bf49da1633ed1db14c6df803098cca1290><pre>ocamlPackages.utop: 2.9.1 -> 2.9.2 (#178245)

https://github.com/ocaml-community/utop/releases/tag/2.9.2</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/9a0b7eddfd8351307f4dea59565453f32d564d59><pre>ocamlPackages.ocaml-migrate-parsetree-2: 2.3.0 -> 2.4.0 (#178244)

https://github.com/ocaml-ppx/ocaml-migrate-parsetree/releases/tag/2.4.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/720b350730182239029212ab0b6678e39355ade6><pre>ocaml-ng.ocamlPackages_4_05.lablgtk: add -fcommon workaround

Workaround build failure on -fno-common toolchains like upstream
gcc-10. Otherwise build fails as:

    ld: ml_gtktree.o:(.bss+0x0): multiple definition of
      `ml_table_extension_events\'; ml_gdkpixbuf.o:(.bss+0x0): first defined here</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/98e0b747df49e3edd1aa2c4e7fcc98361a17b09f...170a413797473733c5be0dd08cdbbab0e39b8aae