### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1656835607,
-        "narHash": "sha256-zONMAG6JSfGyW20AsVWGnlZwNWws6Q/7IT0oDNGc1xY=",
+        "lastModified": 1656964352,
+        "narHash": "sha256-pA4cdXMkXt/2PEkSQFz2RvOAhqSccYcU9WMtCM6h+7Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "18b14a254dca6b68ca0ce2ce885ce2b550065799",
+        "rev": "95cc37ab9a2b9d402a2f6df83d520e7dd19c5f4d",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "18b14a254dca6b68ca0ce2ce885ce2b550065799",
+        "rev": "95cc37ab9a2b9d402a2f6df83d520e7dd19c5f4d",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "ocaml-packages-overlay";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=18b14a254dca6b68ca0ce2ce885ce2b550065799";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=95cc37ab9a2b9d402a2f6df83d520e7dd19c5f4d";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href=https://github.com/NixOS/nixpkgs/commit/d85989da311dbad712b17e084bd235eba8975503><pre>ocamlPackages.fmt: 0.8.9 -> 0.9.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/162c51e86fe800eb3cc4e6b3de6645f7dbd34121><pre>ocamlPackages.mirage-channel: 4.0.1 → 4.1.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/604a9086940c2f438fdf45e4670e2c49f54539a3><pre>ocamlPackages.mirage-console: 4.0.0 → 5.1.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/390681fdaff64e29a30e03a20c12f937ec3a1902><pre>ocamlPackages.optint: 0.1.0 → 0.2.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/6bc3638cf4c1b421d2aceeb598ce848b6e41af76><pre>ocamlPackages.duff: 0.4 → 0.5</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/b6e76635561f4fed78a49124061f3d841627090d><pre>ocamlPackages.atdgen: 2.4.1 → 2.9.1</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/e69aee3280033dd7fbf90bfe479fc279e43a365e><pre>ocamlPackages.io-page: 2.3.0 → 2.4.0

ocamlPackages.mirage-block: 2.0.1 → 3.0.0
ocamlPackages.mirage-block-ramdisk: disable tests
ocamlPackages.mirage-block-unix: 2.12.1 → 2.14.1
ocamlPackages.mirage-unix: 4.0.0 → 4.0.1
ocamlPackages.vchan: 6.0.0 → 6.0.1
ocamlPackages.wodan-unix: mark as broken</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/6791c3ae1163be0f6b5fd9d1da61366f2e0f246e><pre>ocamlPackages.io-page: 2.4.0 → 3.0.0</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/1cfe539b03993e01600ef55bbbaa1163f35d5b78><pre>ocamlPackages.digestif: 1.1.0 → 1.1.2</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/76a24f2d7955f245a0e7eb2fbc595fd3cb562f6c><pre>ocamlPackages.secp256k1-internal: 0.2 → 0.3</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/c2f68f081c92d51df57154522a283739ab724a49><pre>ocamlPackages.batteries: 3.4.0 -> 3.5.1</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/18b14a254dca6b68ca0ce2ce885ce2b550065799...95cc37ab9a2b9d402a2f6df83d520e7dd19c5f4d