### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1658191632,
-        "narHash": "sha256-RTYlMX97mtFUUUbDQOa6gxeWqdGC/fjsC5y9qpqP+kI=",
+        "lastModified": 1658604085,
+        "narHash": "sha256-mEp3HwrGSpVGBs1Ls5f6LphbfyKYKoyS9PRgY/ziKMs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "08e93dbc3765047da5cef623ca98150e2e6ebd82",
+        "rev": "8ad9860b50370b585a248c1b938cbd0d12afe1c2",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "08e93dbc3765047da5cef623ca98150e2e6ebd82",
+        "rev": "8ad9860b50370b585a248c1b938cbd0d12afe1c2",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "ocaml-packages-overlay";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=08e93dbc3765047da5cef623ca98150e2e6ebd82";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=8ad9860b50370b585a248c1b938cbd0d12afe1c2";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -191,18 +191,6 @@ with oself;
     nativeBuildInputs = o.nativeBuildInputs ++ [ pkg-config-script ];
   });
 
-  containers = osuper.containers.overrideAttrs (o: {
-    version = "3.7.0";
-    src = builtins.fetchurl {
-      url = "https://github.com/c-cube/ocaml-containers/archive/v3.7.tar.gz";
-      sha256 = "0pn5yl1b6ij1j63qh8y6qazk5qyh1q40zchrwsrsva3yb73s74z9";
-    };
-  });
-
-  cohttp-async = osuper.cohttp-async.overrideAttrs (o: {
-    patches = [ ];
-  });
-
   coin = osuper.coin.overrideAttrs (_: {
     src = builtins.fetchurl {
       url = https://github.com/mirage/coin/releases/download/v0.1.4/coin-0.1.4.tbz;


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href=https://github.com/NixOS/nixpkgs/commit/23432ed4fcf6e3a466c6f6e616834871f65ca621><pre>ocamlPackage.odoc: 1.5.3 -> 2.1.1 (#181884)

build tested by:
fnix build -f.  ocaml-ng.ocamlPackages_4_{05,06,07,08,09,10,11,12,13,14}.odoc
fnix build -f.  ocaml-ng.ocamlPackages_4_{08,09,10,11,12,13,14}.{odoc,curly,mdx}

curly and mdx are the only reverse dependencies in ocaml-modules
according to grep</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/a8ce8ba5dc10fb35f94f90d041a00e6bbec33748><pre>ocamlPackages.containers: 3.6.1 → 3.9</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/d2b3250200e51d9b5557488dd73446abba5a98f3><pre>ocamlPackages.mariadb: 1.1.4 → 1.1.6</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/fbb839c5621628e36fd7365c7bde112cc9b27087><pre>ocamlPackages.cohttp-async: Remove redundant patch that doesn\'t apply</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/08e93dbc3765047da5cef623ca98150e2e6ebd82...8ad9860b50370b585a248c1b938cbd0d12afe1c2