### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1660639432,
-        "narHash": "sha256-2WDiboOCfB0LhvnDVMXOAr8ZLDfm3WdO54CkoDPwN1A=",
+        "lastModified": 1660898250,
+        "narHash": "sha256-6CwNjSHoE5Qv7xuc56AS8pum4vw3d81tM5tanXdlovU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6c6409e965a6c883677be7b9d87a95fab6c3472e",
+        "rev": "b055aadc3d69aa1183d4c88f904c6bda096c9ae5",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6c6409e965a6c883677be7b9d87a95fab6c3472e",
+        "rev": "b055aadc3d69aa1183d4c88f904c6bda096c9ae5",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "ocaml-packages-overlay";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=6c6409e965a6c883677be7b9d87a95fab6c3472e";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=b055aadc3d69aa1183d4c88f904c6bda096c9ae5";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### Commits touching OCaml packages:
* <a href=https://github.com/NixOS/nixpkgs/commit/ad0112769982c19c5d0399adbba769d0421a5c78><pre>ocamlPackages.pythonlib: mark as broken with OCaml ≥ 4.14</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/5fb8ee0ec66c2fe4a02bd5a8067b97598f251b9e><pre>ocamlPackages.notty: disable for OCaml ≥ 4.14</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/bc71e3099b5d3d211b5cf2b17c1adb11fd14c5d8><pre>ocaml: default to version 4.14</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/7ed0a6f85f4f86acd0fde7ba91f7cea4b9d7c0a9><pre>ocamlPackages.graphql: 0.13.0 → 0.14.0

ocamlPackages.irmin-graphql: mark as broken</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/a06e854f239c0cafc9e35cdaa233568fb3affeab><pre>ocamlPackages.cmdliner_1_1: disable for OCaml < 4.08</pre></a>
* <a href=https://github.com/NixOS/nixpkgs/commit/ec8d3bc39b8c9b805a15ded2ce2b5e153d0736fe><pre>ocamlPackages.crunch: 3.1.0 → 3.3.1</pre></a>

#### Diff URL: https://github.com/NixOS/nixpkgs/compare/6c6409e965a6c883677be7b9d87a95fab6c3472e...b055aadc3d69aa1183d4c88f904c6bda096c9ae5