### PR TITLE
Fix postgres on m1

### DIFF
--- a/overlay/default.nix
+++ b/overlay/default.nix
@@ -47,8 +47,9 @@ in
   # Other packages
 
   # Stripped down postgres without the `bin` part, to allow static linking
-  # with musl
-  libpq = (super.postgresql.override {
+  # with musl.
+  # postgresql == postgresql_14 seems broken on M1
+  libpq = (super.postgresql_13.override {
     enableSystemd = false;
     gssSupport = false;
     openssl = self.openssl-oc;


### PR DESCRIPTION
postgresql v14 seems broken on m1